### PR TITLE
hidden emote

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -689,7 +689,29 @@ private void SendEntityWhisper(
 
         if (checkEmote)
             TryEmoteChatInput(source, action);
-        SendInVoiceRange(ChatChannel.Emotes, name, action, wrappedMessage, obfuscated: "", obfuscatedWrappedMessage: "", source, range, author);
+            
+        // Taken more or less from whispering
+        // Get all people who could receive the message in normal speaking range
+        foreach (var (session, data) in GetRecipients(source, VoiceRange))
+        {
+            EntityUid listener;
+
+            if (session.AttachedEntity is not { Valid: true } playerEntity)
+                continue;
+
+            listener = session.AttachedEntity.Value;
+
+            // If recipient is too far, won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
+            if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
+                continue;
+
+            // If recipient can see the entity performing the emote, show them a popup and send them a chat message with the emote
+            if (_examineSystem.InRangeUnOccluded(source, listener, VoiceRange))
+            {
+                _chatManager.ChatMessageToOne(ChatChannel.Emotes, action, wrappedMessage, source, false, session.Channel);
+            }
+        }
+
         if (!hideLog)
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user} as {name}: {action}");


### PR DESCRIPTION
- fix: эмоуты теперь видно только при условие зрительного контакта. То есть через стены и прочие структуры - они в чате не будут отображаться, как и указываться