### PR TITLE
Flamethrower nerf

### DIFF
--- a/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
+++ b/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
@@ -168,7 +168,7 @@
 - type: listing
   id: UplinkPPSH41Bundle
   name: набор "PPSH41"
-  description: ПиПиСиЭйч 41, стандартный пистолет-пулемет на вооружении СССП, попал на черный рынок из-за частых "набегов" на склады СССП, явно не проданных местными командирами. В комплетке 2 магазина.
+  description: ППШ 41, стандартный пистолет-пулемет на вооружении СССП, попал на черный рынок из-за частых "набегов" на склады СССП, явно не проданных местными командирами. В комплетке 2 магазина.
   icon: { sprite: Backmen/Objects/Weapons/Gunsx64/SMGs/ppsh41/big.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateFilledPPSH41
   cost:
@@ -393,11 +393,11 @@
 - type: listing
   id: UplinkFlamethrowerBundle
   name: набор "Огнемет М6"
-  description: Огнемет имеющий шланг под специальный резервуар с огненой смесью, которая способна гореть даже в полном вакууме! Имеет в наборе 1 powerpack.
+  description: Огнемет имеющий шланг под специальный резервуар с огненой смесью, идущей в комплекте.
   icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/M6/big.rsi, state: icon }
   productEntity: CrateFlamethrowerBundle
   cost:
-    Telecrystal: 12
+    Telecrystal: 13
   categories:
   - UplinkBundles
 
@@ -413,27 +413,27 @@
       - id: WeaponflamethrowerSG
       - id: PowerpackFlame
 
-- type: listing
-  id: UplinkFlamethrower
-  name: Огнемет М6
-  description: Огнемет с небольшой специальным портом под маленькие баллоны с огненой смесью, которая способна гореть даже в полном вакууме!
-  icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/M6/big.rsi, state: icon }
-  productEntity: FirethrowerGun
-  cost:
-    Telecrystal: 5
-  categories:
-  - UplinkWeaponry
+#- type: listing
+#  id: UplinkFlamethrower
+#  name: Огнемет М6
+#  description: Огнемет с небольшой специальным портом под маленькие баллоны с огненой смесью, которая способна гореть даже в полном вакууме!
+#  icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/M6/big.rsi, state: icon }
+#  productEntity: FirethrowerGun
+#  cost:
+#    Telecrystal: 8
+#  categories:
+#  - UplinkWeaponry
 
-- type: listing
-  id: UplinkFuelTankFirethrower
-  name: Топливный бак
-  description: Топливный бак для огнемёта.
-  icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/tank.rsi, state: base }
-  productEntity: FuelTankFirethrower
-  cost:
-    Telecrystal: 1
-  categories:
-  - UplinkAmmo
+#- type: listing
+#  id: UplinkFuelTankFirethrower
+#  name: Топливный бак
+#  description: Топливный бак для огнемёта.
+#  icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/tank.rsi, state: base }
+#  productEntity: FuelTankFirethrower
+#  cost:
+#    Telecrystal: 3
+#  categories:
+#  - UplinkAmmo
 
 - type: listing
   id: UplinkSniperSR127Bundle

--- a/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
+++ b/Resources/Prototypes/_Backmen/Catalog/uplink_nomad.yml
@@ -397,7 +397,7 @@
   icon: { sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/M6/big.rsi, state: icon }
   productEntity: CrateFlamethrowerBundle
   cost:
-    Telecrystal: 13
+    Telecrystal: 16
   categories:
   - UplinkBundles
 

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
@@ -37,8 +37,8 @@
       - BACK
       - SUITSTORAGE
   - type: Gun
-    projectileSpeed: 5
-    fireRate: 10
+    projectileSpeed: 10
+    fireRate: 4
     cameraRecoilScalar: 0.2
     maxAngle: 60
     minAngle: 60
@@ -107,7 +107,7 @@
     whitelist:
       tags:
         - FireThrowerBall
-    capacity: 2000
+    capacity: 300
   - type: ContainerContainer
     containers:
       ballistic-ammo: !type:Container
@@ -143,8 +143,8 @@
   - type: Item
     sprite: Backmen/Objects/Weapons/Gunsx64/Flamethrowers/M6/tiny.rsi
   - type: Gun
-    projectileSpeed: 5
-    fireRate: 10
+    projectileSpeed: 10
+    fireRate: 4
     cameraRecoilScalar: 0.2
     maxAngle: 60
     minAngle: 60
@@ -297,7 +297,7 @@
     - NoSpinOnThrow
     - FireThrowerBall
   - type: TimedDespawn
-    lifetime: 5
+    lifetime: 4
   - type: ThrowingAngle
     angle: 0
   - type: IgniteOnCollide
@@ -348,7 +348,7 @@
         Blunt: 5
   - type: AtmosExposed
   - type: TimedDespawn
-    lifetime: 100
+    lifetime: 50
   - type: Projectile
     deleteOnCollide: false
     damage:
@@ -362,7 +362,7 @@
     sound:
       path: /Audio/Effects/fire.ogg
   - type: IgniteOnCollide
-    fireStacks: 0.8
+    fireStacks: 0.5
     count: 100
     fixtureId: fix1
   - type: Transform
@@ -391,11 +391,11 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: 10
+            Heat: 5
   - type: DamageContacts
     damage:
       types:
-        Heat: 10
+        Heat: 5
     ignoreWhitelist:
       tags:
       - NoSpinOnThrow
@@ -415,7 +415,7 @@
     spreadChance: 0.4
   - type: GrowingKudzu
   - type: TimedDespawn
-    lifetime: 40
+    lifetime: 30
 
 - type: Tag
   id: UpgradeStation

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
@@ -297,7 +297,7 @@
     - NoSpinOnThrow
     - FireThrowerBall
   - type: TimedDespawn
-    lifetime: 4
+    lifetime: 3
   - type: ThrowingAngle
     angle: 0
   - type: IgniteOnCollide

--- a/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Objects/Weapons/Guns/guns64.yml
@@ -41,7 +41,7 @@
     fireRate: 4
     cameraRecoilScalar: 0.2
     maxAngle: 60
-    minAngle: 60
+    minAngle: 50
     selectedMode: FullAuto
     availableModes:
       - FullAuto
@@ -147,7 +147,7 @@
     fireRate: 4
     cameraRecoilScalar: 0.2
     maxAngle: 60
-    minAngle: 60
+    minAngle: 50
     soundGunshot:
       path: /Audio/Weapons/Guns64/Flamethrowers/flamethrower.ogg
     soundEmpty:
@@ -220,7 +220,7 @@
       - TankFlamethrower
   - type: BallisticAmmoProvider
     mayTransfer: true
-    capacity: 100
+    capacity: 50
     proto: FireThrowerBall
     whitelist:
       tags:
@@ -250,7 +250,7 @@
   - type: DamageOnLand
     damage:
       types:
-        Blunt: 1
+        Heat: 1
   - type: Damageable
     damageContainer: Biological
   - type: Destructible
@@ -362,7 +362,7 @@
     sound:
       path: /Audio/Effects/fire.ogg
   - type: IgniteOnCollide
-    fireStacks: 0.5
+    fireStacks: 0.75
     count: 100
     fixtureId: fix1
   - type: Transform


### PR DESCRIPTION
## Описание PR
Из аплинка убран очень дешёвый ручной огнемёт, его ранцевая версия осталась, но была занерфлена и теперь стоит дороже. (Я не знаю, как заставить проджектайлы врезаться в стены, они почему-то от них отскакивают, надо исправить)

## Тип PR
- [X] Balance

**Изменения**
:cl:
- remove: Ручной огнемёт M6 удалён из аплинка Синдиката.
- tweak: Ранцевый огнемёт M6 получил сокращённый боезапас, теперь им нельзя уничтожить экипаж пяти станций.
