### PR TITLE
loadouts troubleshooting testmerge

### DIFF
--- a/Resources/Prototypes/Corvax/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Corvax/Loadouts/loadout_groups.yml
@@ -3,7 +3,7 @@
   name: loadout-group-inventory
   minLimit: 0
   maxLimit: 5
-  hidden: true # Until utilized
+  hidden: false # Testmerge troubleshooting
   loadouts: []
 
 - type: loadoutGroup


### PR DESCRIPTION
## Описание PR
### [Testmerge]
Попытка понять, почему спонсорский лоадаут бакмэнов спавнит Сафно на ГСБ одежду СССП.
**Необходимо будет откатить в ближайшее время.**

## Технические детали
Изменил одну строчку, чтобы проверить "инвентарь" Корвакса.