### PR TITLE
Broaden related file paths for codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # Head Mapper
 /Resources/Maps/** @AltMapper
 /Resources/Prototypes/Maps/** @AltMapper
-/Resources/Prototypes/_Ganimed/Maps/** @AltMapper
+/Resources/Prototypes/*/Maps/** @AltMapper
 
 # Sprites and design (Head Spriter vacant)
 # *.png
@@ -31,10 +31,10 @@
 
 # Unique content
 /Resources/Prototypes/Loadouts/ @HyperB1
-/Resources/Prototypes/_Ganimed/Loadouts/ @HyperB1
+/Resources/Prototypes/*/Loadouts/ @HyperB1
 /Resources/Prototypes/_Ganimed/Entities/Clothing/ @AltMapper
 /Resources/Prototypes/Entities/Objects/Weapons/ @RedSpyy
-/Resources/Prototypes/_Ganimed/Entities/Objects/Weapons/ @RedSpyy
+/Resources/Prototypes/*/Entities/Objects/Weapons/ @RedSpyy
 
 # Lore, Wiki, Guidebook & Rules
 *.xml @HyperB1


### PR DESCRIPTION
## Описание PR
### [GitHub]
Расширил списки связанных файлов у некоторых владельцев кода на путь любой ветки, а не только `/_Ganimed/`.
Если контент портируется с другой ветки или если путь `_Ganimed` когда-либо изменит название, то это не доставит проблем.