### PR TITLE
[TEST] merged Pr discord

### DIFF
--- a/.github/workflows/pr-merged-to-discord.yml
+++ b/.github/workflows/pr-merged-to-discord.yml
@@ -1,0 +1,66 @@
+name: Notify Discord on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract PR info and send to Discord
+        run: |
+          PR_BODY=$(jq -r .pull_request.body "$GITHUB_EVENT_PATH")
+          AUTHOR_LOGIN="${{ github.event.pull_request.user.login }}"
+          AUTHOR_AVATAR="${{ github.event.pull_request.user.avatar_url }}"
+
+          DESCRIPTION=$(echo "$PR_BODY" | awk '/## Описание PR/{flag=1; next} /^## /{flag=0} flag' | sed '/^<!--/,/-->/d' | sed '/^\s*$/d')
+          if [ -z "$DESCRIPTION" ]; then
+            DESCRIPTION="_(нет описания)_"
+          fi
+
+          CHANGELOG=$(echo "$PR_BODY" | awk '/## Список изменений/{flag=1; next} /^## /{flag=0} flag' | grep -E '^\s*-\s*(add|remove|tweak|fix):')
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="_(нет изменений в changelog)_"
+          fi
+
+          MEDIA_URL=$(echo "$PR_BODY" | awk '/## Медиа/{flag=1; next} /^## /{flag=0} flag' | grep -oE 'https?://[^ ]+\.(png|jpg|jpeg|gif)' | head -n 1)
+
+          EMBED_COLOR=3447003
+
+          ESCAPED_DESCRIPTION=$(echo "$DESCRIPTION" | jq -Rs .)
+          ESCAPED_CHANGELOG=$(echo "$CHANGELOG" | jq -Rs .)
+          ESCAPED_MEDIA_URL=$(echo "$MEDIA_URL" | jq -Rs .)
+
+          echo '{
+            "content": "**✅ PR #'"${{ github.event.pull_request.number }}"' был замержен в `'"${{ github.event.pull_request.base.ref }}"'`**",
+            "embeds": [
+              {
+                "author": {
+                  "name": "'"$AUTHOR_LOGIN"'",
+                  "icon_url": "'"$AUTHOR_AVATAR"'"
+                },
+                "title": "Pull Request #'"${{ github.event.pull_request.number }}"'",
+                "color": '"$EMBED_COLOR"',
+                "fields": [
+                  {
+                    "name": "Описание",
+                    "value": '"$ESCAPED_DESCRIPTION"'
+                  },
+                  {
+                    "name": "Список изменений",
+                    "value": '"$ESCAPED_CHANGELOG"'
+                  }
+                ],
+                '"${MEDIA_URL:+
+                "\"image\": {\"url\": $ESCAPED_MEDIA_URL},"}'
+                "timestamp": "'"$(date --utc +%Y-%m-%dT%H:%M:%SZ)"'"
+              }
+            ]
+          }' > payload.json
+
+          curl -X POST -H "Content-Type: application/json" \
+            -d @payload.json \
+            "${{ secrets.DISCORD_WEBHOOK }}"


### PR DESCRIPTION
Вот пример текста для описания в PR — чтобы объяснить, как сделали интеграцию отправки замерженных PR в Discord в одном компактном embed с аватаром автора и fallback'ами:

---

## Описание PR

Добавлена автоматическая отправка уведомлений в Discord при слиянии Pull Request на GitHub.

Теперь при замерже PR в указанную ветку (например, main) в Discord будет приходить компактное сообщение с подробной информацией о PR.

---

## Технические детали

* Созан GitHub Actions workflow, который срабатывает на событие `pull_request` с типом `closed` и проверяет, что PR был замержен.
* Из тела PR парсятся:

  * раздел **Описание** (с сохранением форматирования, без комментариев);
  * раздел **Список изменений** — только строки с префиксами `add`, `fix`, `remove`, `tweak`;
  * первая картинка из раздела **Медиа** (если есть).

  * Автор embed — имя пользователя, отправившего PR, с аватаром GitHub (без ссылки).
  * Заголовок — номер PR.
  * В embed добавлены два поля: **Описание** и **Список изменений**.
  * При наличии картинки она показывается в embed.
* Добавлена обработка пустых полей — подставляется fallback-текст.

---

## Чек-лист

* [ ] Workflow проходит проверку
* [ ] При замерже PR приходит корректное сообщение в Discord
* [ ] Описание, изменения и аватар автора отображаются корректно
* [ ] Фоллбеки на пустые поля работают

---

## Список изменений

- add: Добавлен GitHub Actions workflow для уведомления Discord о замерже PR