### PR TITLE
remove diamond observer

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/lavaland.yml
@@ -45,8 +45,6 @@
       50: Dead
   - type: Butcherable
     spawned:
-    - id: DiamondOre1
-      amount: 1
     - id: MaterialBones1 #ADT tweak
       maxAmount: 3 #ADT tweak
   - type: MovementSpeedModifier


### PR DESCRIPTION
## Описание PR
Теперь с наблюдатель не падают алмазы при разделке

## Список изменений
:cl: CrimeMoot
- remove: С наблюдателей больше не выпадают алмазы при разделке.