### PR TITLE
Communication interception disable

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -610,7 +610,7 @@
 #    startAnnouncement: station-event-communication-interception // ganimed edit
 #    startAudio:
 #      path: /Audio/Announcements/intercept.ogg
-#    duration: null # the rule has to last the whole round not 1 second
+    duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
 #  - type: AlertLevelInterceptionRule // ganimed edit
   - type: AntagSelection

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -607,12 +607,12 @@
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
-    startAnnouncement: station-event-communication-interception
-    startAudio:
-      path: /Audio/Announcements/intercept.ogg
-    duration: null # the rule has to last the whole round not 1 second
+#    startAnnouncement: station-event-communication-interception // ganimed edit
+#    startAudio:
+#      path: /Audio/Announcements/intercept.ogg
+#    duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
-  - type: AlertLevelInterceptionRule
+#  - type: AlertLevelInterceptionRule // ganimed edit
   - type: AntagSelection
     definitions:
     - prefRoles: [ TraitorSleeper ]

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -607,12 +607,12 @@
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
-#    startAnnouncement: station-event-communication-interception // ganimed edit
+#    startAnnouncement: station-event-communication-interception # ganimed testmerge: no sleeper agents announcement
 #    startAudio:
 #      path: /Audio/Announcements/intercept.ogg
     duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
-#  - type: AlertLevelInterceptionRule // ganimed edit
+#  - type: AlertLevelInterceptionRule # ganimed testmerge: no sleeper agents announcement
   - type: AntagSelection
     definitions:
     - prefRoles: [ TraitorSleeper ]


### PR DESCRIPTION
## Описание PR
Теперь событие "Спящие агенты" никак не информируют станцию о своём присутствие. Это значит что код, и оповещение от центрального командование не будет.

issue: #187 

## Список изменений
:cl: CrimeMoot
- tweak: Событие "Спящие агенты" больше не сопровождается оповещением от Центкома и не влияет на уровень кода. Их присутствие теперь скрыто от экипажа. (Тестовое изменение на некоторое время).