### PR TITLE
Job icon radio tag

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Utility;
 using Content.Shared.CCVar; // Ganimed edit
 using static Robust.Client.UserInterface.Controls.LineEdit;
+using System.Linq; // Ganimed edit
 
 namespace Content.Client.UserInterface.Systems.Chat.Widgets;
 
@@ -142,7 +143,7 @@ public partial class ChatBox : UIWidget
 
     public void Repopulate()
     {
-        Contents.Clear();
+        ClearChatContents(); // Ganimed edit
         _chatStackList = new List<ChatStackData>(_chatStackAmount); // Ganimed, EE - Chat stacking
 
         foreach (var message in _controller.History)
@@ -153,7 +154,7 @@ public partial class ChatBox : UIWidget
 
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
-        Contents.Clear();
+        ClearChatContents(); // Ganimed edit
 
         foreach (var message in _controller.History)
         {
@@ -165,6 +166,21 @@ public partial class ChatBox : UIWidget
             _controller.ClearUnfilteredUnreads(channel);
         }
     }
+
+    // Ganimed edit START
+    private void ClearChatContents()
+    {
+        Contents.Clear();
+
+        foreach (var child in Contents.Children.ToArray())
+        {
+            if (child.Name != "_v_scroll")
+            {
+                Contents.RemoveChild(child);
+            }
+        }
+    }
+    // Ganimed edit END
 
     public void AddLine(string message, Color color, int repeat = 0) // Ganimed - Chat stacking - repeatr)
     {

--- a/Content.Client/_Ganimed/IconsJob/JobIconRadioSystem.cs
+++ b/Content.Client/_Ganimed/IconsJob/JobIconRadioSystem.cs
@@ -1,0 +1,25 @@
+using Content.Client.UserInterface.Systems.Chat;
+using Robust.Client.UserInterface;
+
+namespace Content.Client._Ganimed.IconsJob;
+
+public sealed class ChatIconsSystem : EntitySystem
+{
+    [Dependency] private readonly IUserInterfaceManager _uiMan = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        OnRadioIconsChanged(true);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+    }
+
+    private void OnRadioIconsChanged(bool enable)
+    {
+        _uiMan.GetUIController<ChatUIController>().Repopulate();
+    }
+}

--- a/Content.Client/_Ganimed/UI/RichText/JobIconRadioTag.cs
+++ b/Content.Client/_Ganimed/UI/RichText/JobIconRadioTag.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Client.ResourceManagement;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Ganimed.UI.RichText
+{
+    public sealed class RadioIconTag : IMarkupTag
+    {
+        [Dependency] private readonly IResourceCache _cache = default!;
+
+        public string Name => "radicon";
+
+        public bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+        {
+            control = null;
+
+            if (!node.Attributes.TryGetValue("path", out var rawPath))
+            {
+                return false;
+            }
+
+            if (!node.Attributes.TryGetValue("scale", out var scaleStr) || !scaleStr.TryGetLong(out var scaleValue))
+            {
+                scaleValue = 1;
+            }
+
+            control = DrawIcon(rawPath.ToString(), scaleValue.Value);
+            return true;
+        }
+
+        private Control DrawIcon(string path, long scale)
+        {
+            var textureRect = new TextureRect();
+
+            path = ClearString(path);
+
+            textureRect.TexturePath = path;
+            textureRect.TextureScale = new Vector2(scale, scale);
+
+            return textureRect;
+        }
+
+        private static string ClearString(string str)
+        {
+            return str.Replace("=", "")
+                      .Replace(" ", "")
+                      .Replace("\"", "");
+        }
+    }
+}

--- a/Content.Client/_Ganimed/UI/RichText/JobIconTextureTag.cs
+++ b/Content.Client/_Ganimed/UI/RichText/JobIconTextureTag.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.RichText;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Ganimed.UI.RichText
+{
+    public sealed class TextureTag : IMarkupTag
+    {
+        public string Name => "tex";
+
+        public bool TryGetControl(MarkupNode node, [NotNullWhen(true)] out Control? control)
+        {
+            control = null;
+
+            if (!node.Attributes.TryGetValue("path", out var rawPath))
+            {
+                return false;
+            }
+
+            if (!node.Attributes.TryGetValue("scale", out var scale) || !scale.TryGetLong(out var scaleValue))
+            {
+                scaleValue = 1;
+            }
+
+            var textureRect = new TextureRect();
+
+            var path = SanitizeString(rawPath.ToString());
+
+            textureRect.TexturePath = path;
+            textureRect.TextureScale = new Vector2(scaleValue.Value, scaleValue.Value);
+
+            control = textureRect;
+            return true;
+        }
+
+        private static string SanitizeString(string input)
+        {
+            return input.Replace("=", "")
+                        .Replace(" ", "")
+                        .Replace("\"", "");
+        }
+    }
+}

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -14,6 +14,9 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Replays;
 using Robust.Shared.Utility;
+using Content.Shared.Inventory;
+using Content.Shared.PDA;
+using Content.Shared.Access.Components;
 using Content.Server.ADT.Language;  // ADT Languages
 using Content.Shared.ADT.Language;  // ADT Languages
 
@@ -31,11 +34,14 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly LanguageSystem _language = default!;  // ADT Languages
+    [Dependency] private readonly InventorySystem _inventorySystem = default!; // Ganimed edit
 
     // set used to prevent radio feedback loops.
     private readonly HashSet<string> _messages = new();
 
     private EntityQuery<TelecomExemptComponent> _exemptQuery;
+
+    private const string NoIdIconPath = "/Textures/Interface/Misc/job_icons.rsi/NoId.png"; // Ganimed edit
 
     public override void Initialize()
     {
@@ -100,6 +106,16 @@ public sealed class RadioSystem : EntitySystem
         var name = evt.VoiceName;
         name = FormattedMessage.EscapeText(name);
 
+        // Ganimed edit START
+        var tag = Loc.GetString(
+            "radio-icon-tag",
+            ("path", GetIdCardSprite(messageSource)),
+            ("scale", "2")
+        );
+
+        var formattedName = $"{tag} {name}";
+        // Ganimed edit END
+
         SpeechVerbPrototype speech;
         if (evt.SpeechVerb != null && _prototype.TryIndex(evt.SpeechVerb, out var evntProto))
             speech = evntProto;
@@ -151,7 +167,7 @@ public sealed class RadioSystem : EntitySystem
             ("defaultFont", speech.FontId), // ADT Languages
             ("defaultSize", speech.FontSize),   // ADT Languages
             ("channel", $"\\[{channel.LocalizedName}\\]"),
-            ("name", name),
+            ("name", formattedName), // Ganimed edit
             ("message", content));
 
         // ADT Languages start
@@ -163,7 +179,7 @@ public sealed class RadioSystem : EntitySystem
             ("defaultFont", speech.FontId),
             ("defaultSize", speech.FontSize),
             ("channel", $"\\[{channel.LocalizedName}\\]"),
-            ("name", name),
+            ("name", formattedName), // Ganimed edit
             ("message", languageEncodedContent));
         // ADT Languages end
 
@@ -236,7 +252,47 @@ public sealed class RadioSystem : EntitySystem
         _messages.Remove(message);
     }
 
-    /// <inheritdoc cref="TelecomServerComponent"/>
+    // Ganimed edit START
+
+    private string GetIdCardSprite(EntityUid senderUid)
+    {
+
+        var protoId = GetIdCard(senderUid)?.JobIcon;
+        var sprite = NoIdIconPath;
+
+        if (_prototype.TryIndex(protoId, out var prototype))
+        {
+            switch (prototype.Icon)
+            {
+                case SpriteSpecifier.Texture tex:
+                    sprite = tex.TexturePath.CanonPath;
+                    break;
+                case SpriteSpecifier.Rsi rsi:
+                    sprite = rsi.RsiPath.CanonPath + "/" + rsi.RsiState + ".png";
+                    break;
+            }
+        }
+
+        return sprite;
+    }
+    private IdCardComponent? GetIdCard(EntityUid senderUid)
+    {
+        if (!_inventorySystem.TryGetSlotEntity(senderUid, "id", out var idUid))
+            return null;
+
+        if (EntityManager.TryGetComponent(idUid, out PdaComponent? pda) && pda.ContainedId is not null)
+        {
+            if (TryComp<IdCardComponent>(pda.ContainedId, out var idComp))
+                return idComp;
+        }
+        else if (EntityManager.TryGetComponent(idUid, out IdCardComponent? id))
+        {
+            return id;
+        }
+
+        return null;
+    }
+    // Ganimed edit END
     private bool HasActiveServer(MapId mapId, string channelId)
     {
         var servers = EntityQuery<TelecomServerComponent, EncryptionKeyHolderComponent, ApcPowerReceiverComponent, TransformComponent>();

--- a/Resources/Locale/ru-RU/_Ganimed/escape-menu/options-menu.ftl
+++ b/Resources/Locale/ru-RU/_Ganimed/escape-menu/options-menu.ftl
@@ -1,0 +1,1 @@
+radio-icon-tag = [radicon path="{$path}" scale={$scale}]


### PR DESCRIPTION
## Описание PR
В радиосообщениях теперь отображается иконка должности говорящего. Иконка берётся с идентификационной карты — с КПК или обычной ID-карты в руках. Если карта отсутствует, показывается иконка "неизвестно". Работает в том числе и с Агентской картой, и со всеми другими. Основа взята с SS14Starlight

## Медиа
![image](https://github.com/user-attachments/assets/31d817c7-f396-4c45-be42-d2bd00fb41af)

## Чек-лист
- [ ] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [x] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно. -->


## Список изменений
:cl: CrimeMoot
- add: В радиосообщениях теперь отображается иконка должности говорящего. Иконка берётся с идентификационной карты — с КПК или обычной ID-карты в руках. Если карта отсутствует, показывается иконка "неизвестно".