### PR TITLE
Фикс Еретика

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/ADT/Entities/Mobs/Species/ipc.yml
@@ -148,6 +148,8 @@
         type: StrippableBoundUserInterface
       enum.StoreUiKey.Key:
         type: StoreBoundUserInterface
+      enum.HereticLivingHeartKey.Key:
+        type: LivingHeartMenuBoundUserInterface
   - type: IpcScreen
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -48,6 +48,9 @@
     # ADT-SlimeHair-End
       enum.StoreUiKey.Key:                # Чтобы не ломался генокрад
         type: StoreBoundUserInterface               # Чтобы не ломался генокрад
+    # Ganimed-Fix
+      enum.HereticLivingHeartKey.Key:
+        type: LivingHeartMenuBoundUserInterface
   # to prevent bag open/honk spam
   - type: UseDelay
     delay: 0.5


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. Вы можете редактировать этот шаблон PRа, добавляя, убирая или изменяя его пункты и подпункты, по необходимости. -->

## Описание PR
Теперь слаймы и КПБ еретики могут использовать action "Живое сердце", которое показывает цели для жертвоприношения. Без этого фикса игра на этих расах за Еретика невозможна

## Чек-лист
- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [X] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

<!-- Также здесь можно составить список того, что вы планируете сделать, если PR ещё не готов и требует доработки.
- [X] Сделано
- [X] Не сделано -->

## Список изменений
:cl: Gorox
- fix: Еретики слаймы и КПБ теперь могут использовать способность "Живое сердце"