### PR TITLE
disable sponsor incognito

### DIFF
--- a/Resources/Locale/ru-RU/_Ganimed/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/ru-RU/_Ganimed/preferences/ui/humanoid-profile-editor.ftl
@@ -1,1 +1,1 @@
-trait-category-sposnor = Спонсорские трейты
+trait-category-account= Аккаунт

--- a/Resources/Prototypes/_Ganimed/Traits/categories.yml
+++ b/Resources/Prototypes/_Ganimed/Traits/categories.yml
@@ -1,3 +1,3 @@
 - type: traitCategory
-  id: sponsor
-  name: trait-category-sposnor
+  id: account
+  name: trait-category-account

--- a/Resources/Prototypes/_Ganimed/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Ganimed/Traits/disabilities.yml
@@ -2,7 +2,6 @@
   id: Incognito
   name: trait-incognito-name
   description: trait-incognito-desc
-  category: sponsor
-  sponsorOnly: true
+  category: account
   components:
     - type: SetIncognito


### PR DESCRIPTION
## Описание PR
Инкогнито доступно всем.

## Список изменений
:cl: CrimeMoot
- tweak: Черта "Инкогнито", скрывающая имя аккаунта после окончания раунда, теперь доступна всем и может быть выбрана в меню персонализации черт.