### PR TITLE
SponsorLoadoutEffect

### DIFF
--- a/Content.Client/Corvax/Sponsors/SponsorsManager.cs
+++ b/Content.Client/Corvax/Sponsors/SponsorsManager.cs
@@ -2,31 +2,30 @@
 using Content.Shared.Corvax.Sponsors;
 using Robust.Shared.Network;
 
-namespace Content.Client.Corvax.Sponsors
+namespace Content.Client.Corvax.Sponsors;
+
+public sealed class SponsorsManager : ISponsorsManager // Ganimed-Sponsors
 {
-    public sealed class SponsorsManager : ISponsorsManager // Ganimed-Sponsors
+    [Dependency] private readonly IClientNetManager _netMgr = default!;
+
+    private SponsorInfo? _info;
+
+    public void Initialize()
     {
-        [Dependency] private readonly IClientNetManager _netMgr = default!;
-
-        private SponsorInfo? _info;
-
-        public void Initialize()
-        {
-            _netMgr.RegisterNetMessage<MsgSponsorInfo>(msg => _info = msg.Info);
-        }
-
-        public bool TryGetInfo([NotNullWhen(true)] out SponsorInfo? sponsor)
-        {
-            sponsor = _info;
-            return _info != null;
-        }
-
-        // Ganimed-Sponsors start
-        bool ISponsorsManager.TryGetInfo(Robust.Shared.Network.NetUserId userId, [NotNullWhen(true)] out SponsorInfo? sponsor)
-        {
-            sponsor = null;
-            return false;
-        }
-        // Ganimed-Sponsors end
+        _netMgr.RegisterNetMessage<MsgSponsorInfo>(msg => _info = msg.Info);
     }
+
+    public bool TryGetInfo([NotNullWhen(true)] out SponsorInfo? sponsor)
+    {
+        sponsor = _info;
+        return _info != null;
+    }
+
+    // Ganimed-Sponsors start
+    bool ISponsorsManager.TryGetInfo(Robust.Shared.Network.NetUserId userId, [NotNullWhen(true)] out SponsorInfo? sponsor)
+    {
+         sponsor = null;
+        return false;
+    }
+    // Ganimed-Sponsors end
 }

--- a/Content.Client/Corvax/Sponsors/SponsorsManager.cs
+++ b/Content.Client/Corvax/Sponsors/SponsorsManager.cs
@@ -24,7 +24,7 @@ public sealed class SponsorsManager : ISponsorsManager // Ganimed-Sponsors
     // Ganimed-Sponsors start
     bool ISponsorsManager.TryGetInfo(Robust.Shared.Network.NetUserId userId, [NotNullWhen(true)] out SponsorInfo? sponsor)
     {
-         sponsor = null;
+        sponsor = null;
         return false;
     }
     // Ganimed-Sponsors end

--- a/Content.Client/Corvax/Sponsors/SponsorsManager.cs
+++ b/Content.Client/Corvax/Sponsors/SponsorsManager.cs
@@ -2,22 +2,31 @@
 using Content.Shared.Corvax.Sponsors;
 using Robust.Shared.Network;
 
-namespace Content.Client.Corvax.Sponsors;
-
-public sealed class SponsorsManager
+namespace Content.Client.Corvax.Sponsors
 {
-    [Dependency] private readonly IClientNetManager _netMgr = default!;
-
-    private SponsorInfo? _info;
-
-    public void Initialize()
+    public sealed class SponsorsManager : ISponsorsManager // Ganimed-Sponsors
     {
-        _netMgr.RegisterNetMessage<MsgSponsorInfo>(msg => _info = msg.Info);
-    }
+        [Dependency] private readonly IClientNetManager _netMgr = default!;
 
-    public bool TryGetInfo([NotNullWhen(true)] out SponsorInfo? sponsor)
-    {
-        sponsor = _info;
-        return _info != null;
+        private SponsorInfo? _info;
+
+        public void Initialize()
+        {
+            _netMgr.RegisterNetMessage<MsgSponsorInfo>(msg => _info = msg.Info);
+        }
+
+        public bool TryGetInfo([NotNullWhen(true)] out SponsorInfo? sponsor)
+        {
+            sponsor = _info;
+            return _info != null;
+        }
+
+        // Ganimed-Sponsors start
+        bool ISponsorsManager.TryGetInfo(Robust.Shared.Network.NetUserId userId, [NotNullWhen(true)] out SponsorInfo? sponsor)
+        {
+            sponsor = null;
+            return false;
+        }
+        // Ganimed-Sponsors end
     }
 }

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -24,6 +24,7 @@ using Content.Client.Voting;
 using Content.Shared.Administration.Logs;
 using Content.Client.Lobby;
 using Content.Client.Players.RateLimiting;
+using Content.Shared.Corvax.Sponsors; // Ganimed-Sponsors
 using Content.Shared.Administration.Managers;
 using Content.Shared.Chat;
 using Content.Shared.Players.PlayTimeTracking;
@@ -66,7 +67,8 @@ namespace Content.Client.IoC
             collection.Register<PlayerRateLimitManager>();
             collection.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
             collection.Register<TitleWindowManager>();
-            collection.Register<SponsorsManager>(); // Corvax-Sponsors
+            collection.Register<SponsorsManager>();
+            collection.Register<ISponsorsManager, SponsorsManager>(true); // Ganimed-Sponsors
             collection.Register<JoinQueueManager>(); // Corvax-Queue
             collection.Register<DiscordAuthManager>(); // Corvax-DiscordAuth
             collection.Register<ExportManager>(); // ADT Export

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -67,7 +67,7 @@ namespace Content.Client.IoC
             collection.Register<PlayerRateLimitManager>();
             collection.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
             collection.Register<TitleWindowManager>();
-            collection.Register<SponsorsManager>();
+            collection.Register<SponsorsManager>(); // Corvax-Sponsors
             collection.Register<ISponsorsManager, SponsorsManager>(true); // Ganimed-Sponsors
             collection.Register<JoinQueueManager>(); // Corvax-Queue
             collection.Register<DiscordAuthManager>(); // Corvax-DiscordAuth

--- a/Content.Server/Corvax/Sponsors/SponsorsManager.cs
+++ b/Content.Server/Corvax/Sponsors/SponsorsManager.cs
@@ -17,7 +17,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Server.Corvax.Sponsors;
 
-public sealed class SponsorsManager
+public sealed class SponsorsManager : ISponsorsManager // Ganimed-Sponsors
 {
     [Dependency] private readonly IServerNetManager _netMgr = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
@@ -48,6 +48,8 @@ public sealed class SponsorsManager
         _netMgr.Connected += OnConnected;
         _netMgr.Disconnect += OnDisconnect;
 
+        IoCManager.Register<ISponsorsManager, SponsorsManager>(true); // Ganimed-Sponsors
+
         _sawmill.Info($"[Init] Sponsor API URL (from CVar): '{_apiUrl}'");
     }
 
@@ -55,6 +57,14 @@ public sealed class SponsorsManager
     {
         return _cachedSponsors.TryGetValue(userId, out sponsor);
     }
+
+    // Ganimed-Sponsors start
+    bool ISponsorsManager.TryGetInfo([NotNullWhen(true)] out SponsorInfo? info)
+    {
+        info = null;
+        return false;
+    }
+    // Ganimed-Sponsors end
 
     private async Task OnConnecting(NetConnectingArgs e)
     {
@@ -131,20 +141,6 @@ public sealed class SponsorsManager
     public bool TryGetSpawnEquipment(NetUserId userId, string? jobPrototype, [NotNullWhen(true)] out string? spawnEquipment)
     {
         spawnEquipment = null;
-
-        // // ТЕСТОВЫЕ ДАННЫЕ - НАЧАЛО (удалить в мастере) (ИМИТАЦИЯ СПОНСОРКИ)
-        // var sponsorData = new SponsorInfo
-        // {
-        //     CharacterName = "TestSponsor",
-        //     Tier = 4,
-        //     OOCColor = "#FF0000",
-        //     HavePriorityJoin = true,
-        //     ExtraSlots = 2,
-        //     AllowedMarkings = new[] { "marking1", "marking2" },
-        //     ExpireDate = DateTime.Now.AddDays(30),
-        //     AllowJob = true
-        // };
-        // // ТЕСТОВЫЕ ДАННЫЕ - КОНЕЦ
 
         // Получаем sponsorData юсера
         if (!TryGetInfo(userId, out var sponsorData))

--- a/Content.Shared/Corvax/Sponsors/ISponsorsManager.cs
+++ b/Content.Shared/Corvax/Sponsors/ISponsorsManager.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics.CodeAnalysis;
+using Robust.Shared.Network;
+
+namespace Content.Shared.Corvax.Sponsors
+{
+    public interface ISponsorsManager
+    {
+        bool TryGetInfo([NotNullWhen(true)] out SponsorInfo? info);
+        bool TryGetInfo(NetUserId userId, [NotNullWhen(true)] out SponsorInfo? info);
+    }
+}

--- a/Content.Shared/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
@@ -3,14 +3,18 @@ using Content.Shared.Corvax.Sponsors;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Preferences.Loadouts.Effects;
 
 /// <summary>
-/// Разрешает выбирать лодаут только спонсорам. 
+/// Разрешает выбирать лодаут только спонсорам с опциональным ограничением по Tier.
 /// </summary>
 public sealed partial class SponsorLoadoutEffect : LoadoutEffect
 {
+    [DataField("tier")]
+    public int? RequiredTier { get; private set; }
+
     public override bool Validate(
         HumanoidCharacterProfile profile,
         RoleLoadout loadout,
@@ -25,22 +29,36 @@ public sealed partial class SponsorLoadoutEffect : LoadoutEffect
 
         var net = collection.Resolve<INetManager>();
         var isSponsor = false;
+        SponsorInfo? info = null;
 
         if (net.IsClient)
         {
             if (collection.TryResolveType<ISponsorsManager>(out var sponsorsClient))
-                isSponsor = sponsorsClient.TryGetInfo(out var info) && info != null;
+                isSponsor = sponsorsClient.TryGetInfo(out info) && info != null;
         }
         else
         {
             if (collection.TryResolveType<ISponsorsManager>(out var sponsorsServer))
-                isSponsor = sponsorsServer.TryGetInfo(session.UserId, out var info) && info != null;
+                isSponsor = sponsorsServer.TryGetInfo(session.UserId, out info) && info != null;
         }
 
-        if (!isSponsor)
+        if (!isSponsor || info == null)
         {
             reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString("loadout-sponsor-only"));
             return false;
+        }
+
+        if (RequiredTier.HasValue)
+        {
+            var userTier = info.Tier ?? 0;
+            if (userTier < RequiredTier.Value)
+            {
+                reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString(
+                    "loadout-sponsor-tier-restriction",
+                    ("requiredTier", RequiredTier.Value),
+                    ("userTier", userTier)));
+                return false;
+            }
         }
 
         return true;

--- a/Content.Shared/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Corvax.Sponsors;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Preferences.Loadouts.Effects;
+
+/// <summary>
+/// Разрешает выбирать лодаут только спонсорам. 
+/// </summary>
+public sealed partial class SponsorLoadoutEffect : LoadoutEffect
+{
+    public override bool Validate(
+        HumanoidCharacterProfile profile,
+        RoleLoadout loadout,
+        ICommonSession? session,
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = null;
+
+        if (session == null)
+            return true;
+
+        var net = collection.Resolve<INetManager>();
+        var isSponsor = false;
+
+        if (net.IsClient)
+        {
+            if (collection.TryResolveType<ISponsorsManager>(out var sponsorsClient))
+                isSponsor = sponsorsClient.TryGetInfo(out var info) && info != null;
+        }
+        else
+        {
+            if (collection.TryResolveType<ISponsorsManager>(out var sponsorsServer))
+                isSponsor = sponsorsServer.TryGetInfo(session.UserId, out var info) && info != null;
+        }
+
+        if (!isSponsor)
+        {
+            reason = FormattedMessage.FromMarkupOrThrow(Loc.GetString("loadout-sponsor-only"));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
+++ b/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
@@ -1,1 +1,2 @@
 loadout-sponsor-only = [color=yellow]Доступно только спонсорам.[/color]
+loadout-sponsor-tier-restriction = Доступно только спонсорам [color=yellow]{ $requiredTier }[/color]-го уровня. Ваш текущий уровень: [color=yellow]{ $userTier }[/color].


### PR DESCRIPTION
## Описание PR
Внедрена полноценная интеграция системы спонсорских лодаутов. Теперь выбор лодаутов можно ограничивать только для спонсоров с помощью нового эффекта `SponsorLoadoutEffect`. 

Пример использования в YAML-конфигурации лодаута:

```yaml
- type: loadout
  id: CaptainWintercoat
  equipment:
    outerClothing: ClothingOuterWinterCap
  effects:
    - !type:SponsorLoadoutEffect
      tier: 2 # необязательный параметр для ограничения по уровню спонсорства. Должно быть ровно или больше.
````

## Медиа

![image](https://github.com/user-attachments/assets/f813b11b-1b1f-4f97-aca1-fd17daf405e1)
![image](https://github.com/user-attachments/assets/b2b39a2a-6fc5-480d-bd06-180afb65d433)
