### PR TITLE
radioTextIncrease fix

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Ears/headsets.yml
@@ -15,7 +15,7 @@
   - type: Sprite
     sprite: Clothing/Ears/Headsets/servicesecurity.rsi
   - type: Headset # ganimed edit
-    radioTextIncrease: 4
+    radioTextIncrease: 3
 
 - type: entity
   parent: ClothingHeadset

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -91,7 +91,7 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/centcom.rsi
   - type: Headset # ganimed edit
-    radioTextIncrease: 5
+    radioTextIncrease: 3
 
 - type: entity
   parent: [ClothingHeadset, BaseCommandContraband]
@@ -108,7 +108,7 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/command.rsi
   - type: Headset # ganimed edit
-    radioTextIncrease: 4
+    radioTextIncrease: 3
 
 - type: entity
   parent: ClothingHeadset

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -41,7 +41,7 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/centcom.rsi
   - type: Headset # ganimed edit
-    radioTextIncrease: 6
+    radioTextIncrease: 3
 
 - type: entity
   parent: [ClothingHeadsetAlt, BaseCommandContraband]
@@ -57,7 +57,7 @@
   - type: Clothing
     sprite: Clothing/Ears/Headsets/command.rsi
   - type: Headset # ganimed edit
-    radioTextIncrease: 4
+    radioTextIncrease: 3
 
 - type: entity
   parent: [ClothingHeadsetAlt, BaseCommandContraband]


### PR DESCRIPTION
## Описание PR
Исправлена проблема с отображением текста громкости гарнитуры капитана и ЦК при значении 4> — длинные сообщения обрезались снизу. Теперь у капитана и ЦК значение громкости выставлено на 3, что решает эту проблему. У других глав значение оставлено без изменений.

## Список изменений
:cl: CrimeMoot
- fix: Уменьшен размер шрифта громкости гарнитуры у капитана и ЦК с 4/5/6 до 3, чтобы избежать обрезания длинных сообщений вниз экрана.