### PR TITLE
disable font

### DIFF
--- a/Resources/Prototypes/ADT/Languages/collective-mind.yml
+++ b/Resources/Prototypes/ADT/Languages/collective-mind.yml
@@ -6,7 +6,7 @@
     color: "#3de500"
     showRank: false
     showName: false
-    font: Miroslav
+  #  font: Miroslav # Ganimed edit
     fontSize: 14
 
 - type: language
@@ -35,7 +35,7 @@
     color: "#356bff"
     showRank: true
     showName: false
-    font: Pixelizer
+  #  font: Pixelizer # Ganimed edit
     fontSize: 15
 
 - type: language
@@ -47,5 +47,5 @@
     color: "#b61e19"
     showRank: false
     showName: false
-    font: Specialelite
+  #  font: Specialelite # Ganimed edit
     fontSize: 14

--- a/Resources/Prototypes/ADT/Languages/roundstart.yml
+++ b/Resources/Prototypes/ADT/Languages/roundstart.yml
@@ -155,7 +155,7 @@
     - ира
     - хето
     - етто
-    font: CarloMelowSans
+  #  font: CarloMelowSans # Ganimed edit
     fontSize: 14
 
 # Spoken by the Lizard race.
@@ -485,7 +485,7 @@
       chat-speech-verb-suffix-exclamation-strong: [ громко констатирует, громко сообщает ]
       chat-speech-verb-suffix-exclamation: [ громко констатирует, громко сообщает ]
       Default: [ констатирует, сообщает, докладывает ]
-    font: Pixelizer
+  #  font: Pixelizer # Ganimed edit
     fontSize: 15
 
 # Borgs
@@ -505,7 +505,7 @@
       chat-speech-verb-suffix-exclamation-strong: [ громко констатирует, громко сообщает ]
       chat-speech-verb-suffix-exclamation: [ громко констатирует, громко сообщает ]
       Default: [ констатирует, сообщает, докладывает ]
-    font: Pixelizer
+  #  font: Pixelizer # Ganimed edit
     fontSize: 14
 
 # Spoken by the Drask race.

--- a/Resources/Prototypes/ADT/Languages/species-exclusive.yml
+++ b/Resources/Prototypes/ADT/Languages/species-exclusive.yml
@@ -10,7 +10,7 @@
     - шуршит листьями
     - скрежечет ветками
     - шебуршит
-    font: Miroslav
+  #  font: Miroslav # Ganimed edit
     fontSize: 14
     sound:
       path: /Audio/Voice/Diona/diona_scream.ogg
@@ -33,7 +33,7 @@
     - блюп
     - бульп
     - блеб
-    font: Testo
+  #  font: Testo # Ganimed edit
     fontSize: 14
 
 # Spoken by the Novakid race.
@@ -48,7 +48,7 @@
     - разгарается
     - потрескивает огнём
     - издаёт пламенные звуки
-    font: Plantype
+  #  font: Plantype # Ganimed edit
     fontSize: 14
     sound:
       collection: NovakidLaugh
@@ -66,7 +66,7 @@
     - maar
     - mara
     - marr
-    font: CaesarDressing
+  #  font: CaesarDressing # Ganimed edit
     fontSize: 13
 
 - type: language
@@ -108,5 +108,5 @@
     - трынь-трынь
     - пум-пум
     - зак-зак
-    font: Blackcraft
+  #  font: Blackcraft # Ganimed edit
     fontSize: 14


### PR DESCRIPTION
## Описание PR
Убрано выделение шрифтом для всех языков, поскольку оно чрезмерно привлекало внимание и усложняло чтение текста. Цвета и индикация незнания языка при этом сохранены.

## Список изменений
:cl: CrimeMoot
- tweak: Убрано выделение шрифтом для всех языков — текст теперь отображается обычным шрифтом, при этом цвет и  незнания языка остались без изменений.