### PR TITLE
nerf rnd power

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Client.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Client.cs
@@ -91,6 +91,8 @@ public sealed partial class ResearchSystem
         _uiSystem.SetUiState(uid, ResearchClientUiKey.Key, state);
     }
 
+    [Dependency] private readonly PowerReceiverSystem _power = default!; // ganimed edit 
+
     /// <summary>
     /// Tries to get the server belonging to a client
     /// </summary>
@@ -115,6 +117,14 @@ public sealed partial class ResearchSystem
 
         if (!TryComp(component.Server, out serverComponent))
             return false;
+
+        // ganimed edit start
+        if(!_power.IsPowered(uid))
+            return false;
+
+        if(!_power.IsPowered(component.Server.Value))
+            return false;
+        // ganimed edit end
 
         server = component.Server;
         return true;


### PR DESCRIPTION
Добавлена проверка наличия питания на клиентской и серверной сторонах исследовательской системы. Теперь соединение возможно только при наличии питания у обеих сторон. Также невозможно производить предметы через РнД, если исследовательские серверы обесточены.

## Список изменений
:cl: CrimeMoot
- tweak: РнД больше не работает и не отображает технологии, если исследовательские серверы без питания. Производство открытых исследований также недоступно при отсутствии питания у серверов.
