### PR TITLE
fix count DNA

### DIFF
--- a/Content.Server/ADT/Objectives/Systems/StealDnaConditionSystem.cs
+++ b/Content.Server/ADT/Objectives/Systems/StealDnaConditionSystem.cs
@@ -60,12 +60,11 @@ public sealed class StealDnaConditionSystem : EntitySystem
         if (!TryComp<ChangelingComponent>(uid, out var ling))
             return 0f;
 
-        // Умер - не выполнил цель.
-        if (!_mind.IsCharacterDeadIc(mind))
+        if (_mind.IsCharacterDeadIc(mind))
             return 0f;
 
         // Подсчёт требуемых и имеющихся ДНК
-        var count = Math.Clamp(ling.DNAStolen, 0, 1);
-        return count;
+        var stolen = Math.Clamp(ling.DNAStolen, 0, comp.AbsorbDnaCount);
+        return (float)stolen / comp.AbsorbDnaCount;
     }
 }

--- a/Resources/Prototypes/ADT/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/ADT/Objectives/objectiveGroups.yml
@@ -35,7 +35,7 @@
     ChangelingObjectiveGroupState: 1
     ChangelingObjectiveGroupSteal: 1
     ChangelingObjectiveGroupPersonalitySteal: 1
-    ChangelingObjectiveGroupAbsorbDna: 1     # почему ты блять не работаешь
+    ChangelingObjectiveGroupAbsorbDna: 1 
 
 - type: weightedRandom
   id: ChangelingObjectiveGroupSteal


### PR DESCRIPTION
## Описание PR
Исправлена ошибка, из-за которой прогресс цели кражи ДНК не учитывался корректно. Когда жертву кололи скрытым сбором ДНК. Или в целом сбор не выполнялся.

## Технические детали

В коде в `GetProgress` есть строка:

```csharp
if (!_mind.IsCharacterDeadIc(mind))
    return 0f;
```

Расшифровка:  `IsCharacterDeadIc(mind)` возвращает **true**, если персонаж умер ИК (в игре). `!` — логическое отрицание. То есть "если персонаж **не умер** — возвращаем 0 прогресса". Это означает: **пока персонаж жив — прогресс 0**. А когда персонаж умер — дальше идёт подсчёт прогресса.. Почему это неправильно? Цель генокрада — **собрать определённое количество ДНК**. Очевидно, что для этого генокрад должен быть жив. Если персонаж умер — он не может дальше красть ДНК, и цель НЕ должна считаться выполненной. Логично, что когда персонаж мёртв — прогресс = 0.  Значит, условие должно быть наоборот: **если персонаж мёртв — вернуть 0 прогресса и не считать цель выполненной**.

Как я это понял: По логике игровых целей — "собрать n ДНК" выполняется при живом персонаже. Проверка смерти с отрицанием логики - странная идея. Возвращение 0 или 1 прогресса — не подходит для цели с количеством.

Так же,  исходном коде ограничение прогресс от 0 до 1 с помощью

```csharp
Math.Clamp(ling.DNAStolen, 0, 1);
```

Это неправильно, потому что если нужно украсть, например, 10 ДНК, то при 5 украденных у тебя прогресс будет 1 (100%) вместо 0.5 (50%).


## Медиа
![image](https://github.com/user-attachments/assets/427b7c31-a33e-496f-a678-aa6833455595)

## Список изменений
:cl: CrimeMoot
- fix: Исправлен подсчёт украденных ДНК для целей генокрада. Теперь сбор осуществляется нормально и корректно засчитываются.