### PR TITLE
Tweaks to species sizes and clone components fixes

### DIFF
--- a/Content.Server/ADT/SizeAttribute/SizeAttributeWhitelistComponent.cs
+++ b/Content.Server/ADT/SizeAttribute/SizeAttributeWhitelistComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Server.ADT.SizeAttribute
         public bool Short = false;
 
         [DataField("shortscale")]
-        public float ShortScale = 0f;
+        public float ShortScale = 1f;
 
         [DataField("shortDensity")]
         public float ShortDensity = 0f;
@@ -26,7 +26,7 @@ namespace Content.Server.ADT.SizeAttribute
         public bool Tall = false;
 
         [DataField("tallscale")]
-        public float TallScale = 0f;
+        public float TallScale = 1f;
 
         [DataField("tallDensity")]
         public float TallDensity = 0f;

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -58,6 +58,22 @@
   - SpanishAccent
   - StutteringAccent
   - TTS # Corvax-TTS
+# Ganimed-Traits-Fix-Start
+  - SpeechBarks
+  - SizeAttribute
+  - Hemophilia
+  - DeafTrait
+  - Monochromacy
+  - Frail
+  - SoftWalk
+  - Freerunning
+  - Sprinter
+  - FastLockers
+  - HardThrower
+  - FoodConsumptionSpeedModifier
+  - DrunkenResilience
+  - NyaAccent
+# Ganimed-Traits-Fix-End
   blacklist:
     components:
     - AttachedClothing # helmets, which are part of the suit

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -119,9 +119,9 @@
       DionaCollectiveMind: Speak
   - type: SizeAttributeWhitelist
     tall: true
-    tallscale: 1.08
+    tallscale: 1.1
     short: true
-    shortscale: 0.92
+    shortscale: 0.9
   - type: CollectiveMindRank
   # ADT tweak end
 

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -34,9 +34,9 @@
       SolCommon: Speak
   - type: SizeAttributeWhitelist # Frontier
     tall: true
-    tallscale: 1.08
+    tallscale: 1.05
     short: true
-    shortscale: 0.92
+    shortscale: 0.95
   #End ADT tweak
 
 

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -150,9 +150,9 @@
   - type: InjectorsBlocker
   - type: SizeAttributeWhitelist
     tall: true
-    tallscale: 1.12
+    tallscale: 1.1
     short: true
-    shortscale: 0.98
+    shortscale: 0.95
   # ADT tweak end
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -144,9 +144,9 @@
   - type: SlimeHair # ADT-SlimeHair
   - type: SizeAttributeWhitelist # Frontier
     tall: true
-    tallscale: 1.05
+    tallscale: 1
     short: true
-    shortscale: 0.95
+    shortscale: 0.9
   #End ADT tweak
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Сделал в этом PRе две вещи:
- Изменил параметры высокого и низкого роста для разных рас. Это не конечный вариант, поэтому предлагайте правки.
- Добавил недостающие компоненты черт клону, которые не добавили разрабы АДТ. Сейчас при клонировании или спавне парадоксального клона, их параметры могут отличаться, за счёт отсутствия компонентов черт, барков и пр. Пишите, если я забыл какие-то.

## Технические детали
Ещё, в `SizeAttributeWhitelistComponent.cs` я поменял значение `public float ShortScale` и `TallScale` с `0f` на `1f`. Оно не применяется, если не сказанно иного, но я всё равно беспокоюсь, что значение 0 может вызвать ошибку в непредвиденных обстоятельствах.

## Медиа
TODO

## Чек-лист
Требует доработки и тестов.
- [ ] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [ ] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений
:cl: HyperB
- tweak: Пересмотрены цифры высокого и низкого роста для некоторых рас.
- fix: Теперь новые черты сохраняются при клонировании.