### PR TITLE
RND local-ranged

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -18,10 +18,12 @@ namespace Content.Server.Research.Systems
         [Dependency] private readonly IAdminLogManager _adminLog = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+        [Dependency] private readonly EntityLookupSystem _lookup = default!; // Ganimed edit
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
 
+        private static readonly HashSet<Entity<ResearchServerComponent>> ClientLookup = new(); // Ganimed edit
         public override void Initialize()
         {
             base.Initialize();
@@ -40,13 +42,13 @@ namespace Content.Server.Research.Systems
         /// <param name="serverUid"></param>
         /// <param name="serverComponent"></param>
         /// <returns></returns>
-        public bool TryGetServerById(int id, [NotNullWhen(true)] out EntityUid? serverUid, [NotNullWhen(true)] out ResearchServerComponent? serverComponent)
+        public bool TryGetServerById(EntityUid client, int id, [NotNullWhen(true)] out EntityUid? serverUid, [NotNullWhen(true)] out ResearchServerComponent? serverComponent) // Ganimed edit
         {
             serverUid = null;
             serverComponent = null;
 
-            var query = EntityQueryEnumerator<ResearchServerComponent>();
-            while (query.MoveNext(out var uid, out var server))
+            var query = GetServers(client).ToList(); // Ganimed edit
+            foreach (var (uid, server) in query) // Ganimed edit
             {
                 if (server.Id != id)
                     continue;
@@ -61,14 +63,14 @@ namespace Content.Server.Research.Systems
         /// Gets the names of all the servers.
         /// </summary>
         /// <returns></returns>
-        public string[] GetServerNames()
+        public string[] GetServerNames(EntityUid client) // Ganimed edit
         {
-            var allServers = EntityQuery<ResearchServerComponent>(true).ToArray();
+            var allServers = GetServers(client).ToArray(); // Ganimed edit
             var list = new string[allServers.Length];
 
             for (var i = 0; i < allServers.Length; i++)
             {
-                list[i] = allServers[i].ServerName;
+                list[i] = allServers[i].Comp.ServerName; // Ganimed edit
             }
 
             return list;
@@ -78,18 +80,32 @@ namespace Content.Server.Research.Systems
         /// Gets the ids of all the servers
         /// </summary>
         /// <returns></returns>
-        public int[] GetServerIds()
+        public int[] GetServerIds(EntityUid client) // Ganimed edit
         {
-            var allServers = EntityQuery<ResearchServerComponent>(true).ToArray();
+            var allServers = GetServers(client).ToArray(); // Ganimed edit
             var list = new int[allServers.Length];
 
             for (var i = 0; i < allServers.Length; i++)
             {
-                list[i] = allServers[i].Id;
+                list[i] = allServers[i].Comp.Id; // Ganimed edit
             }
 
             return list;
         }
+
+        // Ganimed edit start
+        public HashSet<Entity<ResearchServerComponent>> GetServers(EntityUid client)
+        {
+            ClientLookup.Clear();
+
+            var clientXform = Transform(client);
+            if (clientXform.GridUid is not { } grid)
+                return ClientLookup;
+
+            _lookup.GetGridEntities(grid, ClientLookup);
+            return ClientLookup;
+        }
+        // Ganimed edit end
 
         public override void Update(float frameTime)
         {
@@ -100,7 +116,7 @@ namespace Content.Server.Research.Systems
                     continue;
                 server.NextUpdateTime = _timing.CurTime + server.ResearchConsoleUpdateTime;
 
-                UpdateServer(uid, (int) server.ResearchConsoleUpdateTime.TotalSeconds, server);
+                UpdateServer(uid, (int)server.ResearchConsoleUpdateTime.TotalSeconds, server); // Ganimed edit
             }
         }
     }


### PR DESCRIPTION
## Описание PR
Теперь серверы R&D работают только в пределах локального грида. Это означает, что результаты исследований больше не передаются глобально — они доступны исключительно на том гриде, где расположены сами серверы R&D. Таким образом, шаттлы и другие объекты за пределами станции не получают доступ к этим исследованиям. Работает так же и в обратном направлении.

## Список изменений
:cl: CrimeMoot
- tweak: Теперь сервера исследований работают только в пределах своего грида: Результаты исследований больше не синхронизируются глобально. Доступ к данным возможен только на гриде, где расположен сервер R&D. Шаттлы и удаленные объекты (гриды, другие карты и т.д) не получают эти данные (и наоборот).