### PR TITLE
job_whitelist loadout

### DIFF
--- a/Content.Shared/_Ganimed/Loadouts/Effects/JobRestrictedLoadoutEffect.cs
+++ b/Content.Shared/_Ganimed/Loadouts/Effects/JobRestrictedLoadoutEffect.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Preferences.Loadouts.Effects;
+using Content.Shared.Preferences;
+using Content.Shared.Preferences.Loadouts;
+using Robust.Shared.Player;
+using Robust.Shared.Utility;
+using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
+using Content.Shared.Roles;
+
+namespace Content.Shared._Ganimed.Loadouts.Effects;
+
+[DataDefinition]
+public sealed partial class JobRestrictedLoadoutEffect : LoadoutEffect
+{
+
+    [DataField("whitelistJobs", required: true)]
+    public List<string> WhitelistJobs { get; private set; } = new();
+
+    public override bool Validate(
+        HumanoidCharacterProfile profile,
+        RoleLoadout loadout,
+        ICommonSession? session,
+        IDependencyCollection collection,
+        [NotNullWhen(false)] out FormattedMessage? reason)
+    {
+        reason = null;
+
+        var allowed = false;
+        foreach (var (jobId, priority) in profile.JobPriorities)
+        {
+            if (priority != JobPriority.High)
+                continue;
+
+            if (WhitelistJobs.Contains(jobId))
+            {
+                allowed = true;
+                break;
+            }
+        }
+
+        if (!allowed)
+        {
+            var protoManager = collection.Resolve<IPrototypeManager>();
+
+            var localizedJobs = new List<string>();
+            foreach (var jobId in WhitelistJobs)
+            {
+                if (protoManager.TryIndex<JobPrototype>(jobId, out var jobProto))
+                    localizedJobs.Add(Loc.GetString(jobProto.LocalizedName));
+                else
+                    localizedJobs.Add(jobId); // fallback
+            }
+
+            reason = FormattedMessage.FromMarkupOrThrow(
+                Loc.GetString("loadout-jobrestricted-fail", ("jobs", string.Join(", ", localizedJobs)))
+            );
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
+++ b/Resources/Locale/ru-RU/corvax/preferences/loadouts.ftl
@@ -1,2 +1,3 @@
 loadout-sponsor-only = [color=yellow]Доступно только спонсорам.[/color]
 loadout-sponsor-tier-restriction = Доступно только спонсорам [color=yellow]{ $requiredTier }[/color]-го уровня. Ваш текущий уровень: [color=yellow]{ $userTier }[/color].
+loadout-jobrestricted-fail = [color=orange]Доступно только для профессий:[/color] { $jobs }


### PR DESCRIPTION
## Описание PR
Внедрён новый эффект лодаута `JobRestrictedLoadoutEffect`, который ограничивает возможность выбора и применения лодаута только для заданных профессий с высоким приоритетом. 

```yaml
- type: loadout
  id: FlowerWreath
  storage:
    back:
    - ClothingHeadHatFlowerWreath
  effects:
    - !type:JobRestrictedLoadoutEffect
      whitelistJobs: [ Detective, HeadOfSecurity, SecurityCadet, SecurityOfficer, Warden ]
 ```

## Технические детали
- Добавлен класс `JobRestrictedLoadoutEffect`, унаследованный от `LoadoutEffect`.
- Валидация происходит по списку профессий (`WhitelistJobs`), которые разрешены для эффекта.
- Проверяется активная профессия персонажа через `profile.JobPriorities` и учитывается только профессия с `JobPriority.High`.

<img width="1487" height="784" alt="image" src="https://github.com/user-attachments/assets/1c4d2fae-67f5-4abd-991e-71be9ce23572" />

