### PR TITLE
Increase shuttle FTL range

### DIFF
--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -19,7 +19,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 256f;
+    public const float FTLRange = 512f;
     public const float FTLBufferRange = 8f;
 
     private EntityQuery<MapGridComponent> _gridQuery;

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -19,7 +19,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 512f;
+    public const float FTLRange = 512f; // Ganimed-Tweak: FTL range increased from 256 to 512
     public const float FTLBufferRange = 8f;
 
     private EntityQuery<MapGridComponent> _gridQuery;


### PR DESCRIPTION
## Описание PR
<!-- Ниже опишите ваш Pull Request и все внесённые вами изменения. Что он изменяет и почему? На что это может повлиять и как может отразиться на игровом балансе? Если PR связан с предложением или баг-репортом - приложите ссылку на него. -->
Увеличен радиус FTL-прыжка шаттла с 256 до 512 тайлов (такое значение было до появления VGRoidа), так как с низким значением FTL прыжки ощущаются излишне короткими и почти бессмысленными.

## Медиа
N/A

## Чек-лист
<!-- Это список требований к завершённому PR (если они приемлемы для этих изменений), выполнение которых ускорит его проверку. Отметить с помощью [X]. -->
- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [ ] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений
:cl: HyperB
- tweak: Максимальный радиус БСС-прыжка шаттлов увеличен вдвое - с 256 до 512 тайлов.