### PR TITLE
Небольшой фикс книг с СРП

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Misc/books.yml
@@ -1,8 +1,8 @@
 - type: entity
   id: ADTBookSpaceLaw
   parent: BaseItem
-  name: space law
-  description: A set of Nanotrasen guidelines for keeping law and order on their space stations.
+  name: Корпоративный закон
+  description: Набор правил NanoTrasen для поддержания закона и порядка на своих космических станциях.
   components:
   - type: Sprite
     sprite: ADT/Objects/Misc/books.rsi

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -28,7 +28,7 @@
     # ADT-WikiBooks-Start
     - id: ADTBookSRPcmd
     - id: ADTBookSRPcrg
-    - id: ADTBookPCDcmd
+    #- id: ADTBookPCDcmd #Ganimed-edit
     - id: ADTtelescopicBaton
     # ADT-WikiBooks-End
     # ADT-Tweak Start - частичный откат нерфа утилей
@@ -206,7 +206,7 @@
     # ADT-WikiBooks-Start
     - id: ADTBookSRPcmd
     - id: ADTBookSRPeng
-    - id: ADTBookPCDcmd
+    #- id: ADTBookPCDcmd #Ganimed-edit
     - id: ADTtelescopicBaton
     # ADT-WikiBooks-End
 
@@ -275,7 +275,7 @@
     - id: ADTBriefcaseMedicalFilled
     - id: ADTBookSRPcmd
     - id: ADTBookSRPmed
-    - id: ADTBookPCDcmd
+    #- id: ADTBookPCDcmd #Ganimed-edit
     - id: ADTtelescopicBaton
     - id: OpporozidoneBeakerSmall
     - id: ADTClothingEyesGlassesMedChem
@@ -336,7 +336,7 @@
     # ADT-WikiBooks-Start
     - id: ADTBookSRPcmd
     - id: ADTBookSRPrnd
-    - id: ADTBookPCDcmd
+    #- id: ADTBookPCDcmd #Ganimed-edit
     - id: ADTtelescopicBaton
     - id: ADTBoxAICircuitBoard
     # ADT-WikiBooks-End
@@ -410,8 +410,8 @@
     # ADT-WikiBooks-Start
     - id: ADTBookSRPcmd
     - id: ADTBookSRPsec
-    - id: ADTBookPCDsec
-    - id: ADTBookPCDcmd
+    #- id: ADTBookPCDsec #Ganimed-edit
+    #- id: ADTBookPCDcmd #Ganimed-edit
     - id: ADTtelescopicBaton
     # ADT-WikiBooks-End
     # ADT-SecShuttle-Start

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -28,7 +28,7 @@
       - id: ClothingHandsGlovesKravMaga
       - id: ADTClothingNeckBodyCamera #ADT bodycam
       - id: ADTBookSRPsec
-      - id: ADTBookPCDsec
+      #- id: ADTBookPCDsec #Ganimed-edit
       - id: RemoteSignaller
         amount: 2
       - id: ADTSecShuttleConsoleCircuitboard
@@ -65,7 +65,7 @@
       - id: ClothingHandsGlovesKravMaga
       - id: ADTClothingNeckBodyCamera #ADT bodycam
       - id: ADTBookSRPsec
-      - id: ADTBookPCDsec
+      #- id: ADTBookPCDsec #Ganimed-edit
       - id: RemoteSignaller
         amount: 2
       - id: ADTSecShuttleConsoleCircuitboard
@@ -103,7 +103,7 @@
         prob: 0.5
     # ADT-WikiBooks-Start
       - id: ADTBookSRPsec
-      - id: ADTBookPCDsec
+      #- id: ADTBookPCDsec #Ganimed-edit
     # ADT-WikiBooks-End
 
 # - type: entity
@@ -169,7 +169,7 @@
       - id: ADTClothingNeckBodyCamera
     # ADT-WikiBooks-Start
       - id: ADTBookSRPsec
-      - id: ADTBookPCDsec
+      #- id: ADTBookPCDsec #Ganimed-edit
     # ADT-WikiBooks-End
       - id: ClothingBeltRevolverHolster #Ganimed-edit
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -715,3 +715,6 @@ ADTIconAdventureTime: null
 #Ganimed 2025-06-14
 ADTPoweredShuttleLight: AlwaysPoweredWallLight
 ADTPoweredShuttleLightLED: AlwaysPoweredWallLight
+
+#Gamimed 2025-08-09
+BookSpaceLaw: ADTBookSpaceLaw


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. Вы можете редактировать этот шаблон PRа, добавляя, убирая или изменяя его пункты и подпункты, по необходимости. -->

## Описание PR
Удаляет книги-дубликаты в шкафах.
Заменяется визардскую КЗ книжку на КЗ книжку АДТшников с нашей ссылкой.

## Технические детали
Только YAML

**АХТУНГ!!** Содержит костыльную (тем не менее рабочую) реализацию локализации. Сделано оно именно так, потому что надо поправить книги на АДТ сборке, и докинуть файл локализации там же. Работы там не много, я займусь, но чтоб не ждать полгода пока они примут фикс и пока он дойдет до нас сделано так (нам после фикса на адт всё равно с конфликтами в books.yml ковырятся, во время этого ковыряния костыль и будет ликвидирован).