### PR TITLE
forensics update

### DIFF
--- a/Content.Server/Doors/Systems/DoorSystem.cs
+++ b/Content.Server/Doors/Systems/DoorSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Access;
+using Content.Server.Forensics; // Ganimed edit
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Doors.Components;
@@ -11,6 +12,7 @@ namespace Content.Server.Doors.Systems;
 public sealed class DoorSystem : SharedDoorSystem
 {
     [Dependency] private readonly AirtightSystem _airtightSystem = default!;
+    [Dependency] private readonly ForensicsSystem _forensicsSystem = default!; // Ganimed edit
 
     public override void Initialize()
     {
@@ -50,4 +52,22 @@ public sealed class DoorSystem : SharedDoorSystem
         Dirty(ent, ent.Comp);
         UpdateBoltLightStatus(ent);
     }
+
+    // Ganimed edit start    
+    public override void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartOpening(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+
+    public override void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    {
+        base.StartClosing(uid, door, user, predicted);
+
+        if (user.HasValue)
+            _forensicsSystem.ApplyEvidence(user.Value, uid);
+    }
+    // Ganimed edit end
 }

--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -290,7 +290,7 @@ namespace Content.Server.Forensics
             return DNA;
         }
 
-        private void ApplyEvidence(EntityUid user, EntityUid target)
+        public void ApplyEvidence(EntityUid user, EntityUid target) // Ganimed edit
         {
             if (HasComp<IgnoresFingerprintsComponent>(target))
                 return;

--- a/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
+++ b/Content.Server/Storage/EntitySystems/SpawnItemsOnUseSystem.cs
@@ -7,6 +7,9 @@ using Content.Shared.Interaction.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
+using Robust.Shared.Utility; // Ganimed edit
+using Content.Server.Forensics; // Ganimed edit
+using Content.Server.Forensics.Components; // Ganimed edit
 using static Content.Shared.Storage.EntitySpawnCollection;
 
 namespace Content.Server.Storage.EntitySystems
@@ -19,6 +22,7 @@ namespace Content.Server.Storage.EntitySystems
         [Dependency] private readonly PricingSystem _pricing = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly ForensicsSystem _forensicsSystem = default!; // Ganimed edit
 
         public override void Initialize()
         {
@@ -73,9 +77,26 @@ namespace Content.Server.Storage.EntitySystems
             var spawnEntities = GetSpawns(component.Items, _random);
             EntityUid? entityToPlaceInHands = null;
 
-            foreach (var proto in spawnEntities)
+            // Ganimed edit start
+            for (int i = 0; i < spawnEntities.Count; i++)
             {
+                var proto = spawnEntities[i];
                 entityToPlaceInHands = Spawn(proto, coords);
+
+                if (i < component.Items.Count && component.Items[i].InheritParentForensics)
+                {
+                    if (TryComp<ForensicsComponent>(uid, out var parentForensics))
+                    {
+                        if (!TryComp<ForensicsComponent>(entityToPlaceInHands.Value, out var childForensics))
+                        {
+                            childForensics = EntityManager.AddComponent<ForensicsComponent>(entityToPlaceInHands.Value);
+                        }
+
+                        _forensicsSystem.CopyForensicsFrom(parentForensics, entityToPlaceInHands.Value);
+                    }
+                }
+            // Ganimed edit end
+
                 _adminLogger.Add(LogType.EntitySpawn, LogImpact.Low, $"{ToPrettyString(args.User)} used {ToPrettyString(uid)} which spawned {ToPrettyString(entityToPlaceInHands.Value)}");
             }
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -353,7 +353,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     /// <param name="user"> The user (if any) opening the door</param>
     /// <param name="predicted">Whether the interaction would have been
     /// predicted. See comments in the PlaySound method on the Server system for details</param>
-    public void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartOpening(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Ganimed edit
     {
         if (!Resolve(uid, ref door))
             return;
@@ -448,7 +448,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         return !ev.PerformCollisionCheck || !GetColliding(uid).Any();
     }
 
-    public void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false)
+    public virtual void StartClosing(EntityUid uid, DoorComponent? door = null, EntityUid? user = null, bool predicted = false) // Ganimed edit
     {
         if (!Resolve(uid, ref door))
             return;

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -58,6 +58,11 @@ public partial struct EntitySpawnEntry
 
     [DataField] public int Amount = 1;
 
+    // Ganimed edit start
+    [DataField("inheritParentForensics")]
+    public bool InheritParentForensics = true;
+    // Ganimed edit end
+
     /// <summary>
     ///     How many of this can be spawned, in total.
     ///     If this is lesser or equal to <see cref="Amount"/>, it will spawn <see cref="Amount"/> exactly.
@@ -104,7 +109,7 @@ public static class EntitySpawnCollection
             if (entry.PrototypeId == null)
                 continue;
 
-            var amount = (int) entry.GetAmount(random);
+            var amount = (int)entry.GetAmount(random);
 
             for (var i = 0; i < amount; i++)
             {
@@ -131,7 +136,7 @@ public static class EntitySpawnCollection
                     break;
 
                 // Dice roll succeeded, add item and break loop
-                var amount = (int) entry.GetAmount(random);
+                var amount = (int)entry.GetAmount(random);
 
                 for (var i = 0; i < amount; i++)
                 {
@@ -158,7 +163,7 @@ public static class EntitySpawnCollection
             if (entry.SpawnProbability != 1f && !random.Prob(entry.SpawnProbability))
                 continue;
 
-            var amount = (int) entry.GetAmount(random);
+            var amount = (int)entry.GetAmount(random);
 
             for (var i = 0; i < amount; i++)
             {


### PR DESCRIPTION
## Описание PR
Указано в CL

## Список изменений
:cl: CrimeMoot
- tweak: Все шлюзы теперь всегда сохраняют отпечатки пальцев (или тип перчаток) при их открытии, будучи проходя через них, а не только когда по ним жмешь курсором для открытия. 
- add: Теперь обёртки и все предметы, которые используются в руке и при этом порождают новые объекты, автоматически сохраняют все отпечатки пальцев, волокна и другие следы с исходного предмета. Даже если новые объекты вы напрямую не трогали — например, как упаковка шоколадки, которая при открытии падает на пол — отпечатки и следы будут корректно перенесены на эти объекты.