### PR TITLE
Revert "Communication interception disable (#189)"

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -612,12 +612,12 @@
     weight: 8
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
-#    startAnnouncement: station-event-communication-interception # ganimed testmerge: no sleeper agents announcement
-#    startAudio:
-#      path: /Audio/Announcements/intercept.ogg
+    startAnnouncement: station-event-communication-interception
+    startAudio:
+      path: /Audio/Announcements/intercept.ogg
     duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
-#  - type: AlertLevelInterceptionRule # ganimed testmerge: no sleeper agents announcement
+  - type: AlertLevelInterceptionRule
   - type: AntagSelection
     definitions:
     - prefRoles: [ TraitorSleeper ]


### PR DESCRIPTION
## Описание PR
Reverts CrimeMoot/Ganimed14#189
Откат тестмерджа спустя более двух месяцев тестов. Изменение вышло противоречивым и оправдывается далеко не всегда.

## Чек-лист
- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [ ] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно. (Не требуется)

## Список изменений
:cl: HyperB
- tweak: Спустя два месяца тестов, возвращено оповещение о спящих агентах с повышением кода до синего.