### PR TITLE
Return minimal brightness check

### DIFF
--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -8,8 +8,7 @@ public static class SkinColor
     public const float MaxTintedHuesSaturation = 0.1f;
     public const float MinTintedHuesLightness = 0.85f;
 
-    // ADT-Tweak: Разблокировка палитры доступных цветов для рас, имеющих RGB Смену цвета
-    public const float MinHuesLightness = 0.01f;
+    public const float MinHuesLightness = 0.175f;
 
     public const float MinFeathersHue = 29f / 360;
     public const float MaxFeathersHue = 174f / 360;


### PR DESCRIPTION
## Описание PR
Возвращено ограничение минимальной яркости.
Никаких унатхов цвета #000000.

## Технические детали
Reverts 089f32d
Нет комментариев, так как на апстриме будет рефактор этой системы и этот файл в любом случае удалят.

<!-- ## Медиа -->