### PR TITLE
MaxOccurrences ion storm

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -656,6 +656,7 @@
     weight: 8
     reoccurrenceDelay: 20
     duration: 1
+    maxOccurrences: 1 # Ganimed edit
     startAnnouncement: station-event-ion-storm-start-announcement # Ganimed edit
     startAudio:
       path: /Audio/Corvax/Adminbuse/i-storm1.ogg


### PR DESCRIPTION
## Описание PR
Ионный шторм теперь срабатывает за одну смену лишь один раз.

## Чек-лист
- [x] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [x] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений
:cl: CrimeMoot
- tweak: Ионный шторм теперь срабатывает за одну смену лишь один раз.