### PR TITLE
MaskToggle effect

### DIFF
--- a/Content.Shared/Eye/Blinding/Components/EyeProtectionComponent.cs
+++ b/Content.Shared/Eye/Blinding/Components/EyeProtectionComponent.cs
@@ -3,7 +3,7 @@ namespace Content.Shared.Eye.Blinding.Components;
 /// <summary>
 /// For welding masks, sunglasses, etc.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent]
 public sealed partial class EyeProtectionComponent : Component
 {
     /// <summary>


### PR DESCRIPTION
## Описание PR
Изменено поведение масок: когда маска опущена вниз (toggled), все эффекты от маски перестают работать, как будто маска снята.

## Почему / Баланс
Это изменение делает поведение масок более реалистичным - опущенная маска не должна предоставлять никаких преимуществ или защит. Игроки должны поднимать маску на лицо, чтобы получить эффекты.

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: CrimeMoot
- tweak: Маски теперь теряют все эффекты при опускании вниз с лица. Это значит что маска синдиката не будет защищать от вспышек и прочее.