### PR TITLE
fix CanEnable JetpackSystem

### DIFF
--- a/Content.Client/Movement/Systems/JetpackSystem.cs
+++ b/Content.Client/Movement/Systems/JetpackSystem.cs
@@ -25,8 +25,16 @@ public sealed class JetpackSystem : SharedJetpackSystem
 
     protected override bool CanEnable(EntityUid uid, JetpackComponent component)
     {
-        // No predicted atmos so you'd have to do a lot of funny to get this working.
-        return false;
+        // Ganimed edit start
+        // Check if we're on a grid or map with gravity - jetpacks shouldn't work there.
+        if (TryComp(uid, out TransformComponent? xform))
+        {
+            if (!CanEnableOnGrid(xform.GridUid, xform.MapUid))
+                return false;
+        }
+
+        return true;
+        // Ganimed edit end
     }
 
     private void OnJetpackAppearance(EntityUid uid, JetpackComponent component, ref AppearanceChangeEvent args)

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -101,7 +101,7 @@ public abstract class SharedJetpackSystem : EntitySystem
     private void OnJetpackUserEntParentChanged(EntityUid uid, JetpackUserComponent component, ref EntParentChangedMessage args)
     {
         if (TryComp<JetpackComponent>(component.Jetpack, out var jetpack) &&
-            !CanEnableOnGrid(args.Transform.GridUid))
+            !CanEnableOnGrid(args.Transform.GridUid, args.Transform.MapUid)) // Ganimed edit
         {
             SetEnabled(component.Jetpack, jetpack, false, uid);
 
@@ -143,7 +143,7 @@ public abstract class SharedJetpackSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
+        if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid, xform.MapUid)) // Ganimed edit
         {
             _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
 
@@ -153,17 +153,25 @@ public abstract class SharedJetpackSystem : EntitySystem
         SetEnabled(uid, component, !IsEnabled(uid));
     }
 
-    private bool CanEnableOnGrid(EntityUid? gridUid)
+    protected bool CanEnableOnGrid(EntityUid? gridUid, EntityUid? mapUid = null) // Ganimed edit
     {
         // No and no again! Do not attempt to activate the jetpack on a grid with gravity disabled. You will not be the first or the last to try this.
         // https://discord.com/channels/310555209753690112/310555209753690112/1270067921682694234
 
-        // ADT Tweak start
-        if (gridUid == null || !TryComp<GravityComponent>(gridUid, out var comp))
-            return true;
+        // Ganimed edit start
+        if (gridUid != null && TryComp<GravityComponent>(gridUid, out var gravityComp) && gravityComp.Enabled)
+        {
+            return false;
+        }
 
-        return !comp.Enabled;
-        // ADT Tweak End
+        // Check if map has gravity enabled (e.g., planets like Lavaland)
+        if (mapUid != null && TryComp<GravityComponent>(mapUid, out var mapGravityComp) && mapGravityComp.Enabled)
+        {
+            return false;
+        }
+        // Ganimed edit end
+
+        return true;
     }
 
     private void OnJetpackGetAction(EntityUid uid, JetpackComponent component, GetItemActionsEvent args)


### PR DESCRIPTION
## Описание PR
Изменена логика активации джетпаков. Теперь джетпаки можно активировать только на биомах без гравитации, и никогда на станциях или базах с гравитацией.

## Почему / Баланс
Джетпаки предназначены для использования в условиях отсутствия гравитации. Активация джетпаков на биомах с гравитацией (например Лаваленд) приводила к зависанию игрока в воздухе без возможности движения

## Техническая информация
- [x] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [x] PR закончен и требует просмотра изменений.

## Чейнджлог
:cl: Ganimed14
- tweak: Изменена логика активации джетпаков - теперь работают только на биомах без гравитации, запрещены на станциях и базах с гравитацией. Ранее аванпост и гриды на лаваленде игнорировали это правило