### PR TITLE
Remove artificial humans

### DIFF
--- a/Resources/Prototypes/ADT/Catalog/Cargo/cargo_livestock.yml
+++ b/Resources/Prototypes/ADT/Catalog/Cargo/cargo_livestock.yml
@@ -1,9 +1,11 @@
-- type: cargoProduct
-  id: LivestockArtificialHumanCube
-  icon:
-    sprite: ADT/Objects/Misc/humancube.rsi
-    state: box
-  product: ADTHumanCubeBox
-  cost: 7000
-  category: cargoproduct-category-name-livestock
-  group: market
+# Ganimed-Remove-Start
+#- type: cargoProduct
+#  id: LivestockArtificialHumanCube
+#  icon:
+#    sprite: ADT/Objects/Misc/humancube.rsi
+#    state: box
+#  product: ADTHumanCubeBox
+#  cost: 7000
+#  category: cargoproduct-category-name-livestock
+#  group: market
+# Ganimed-Remove-End

--- a/Resources/Prototypes/Recipes/Lathes/Packs/animal_cubes.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/animal_cubes.yml
@@ -6,7 +6,7 @@
   - MonkeyCube
   - KoboldCube
   - CowCube
-  - ADTCubeGondola # ADT Tweak
+  # - ADTCubeGondola # ADT Tweak # Ganimed-Remove
   - GoatCube
   - MothroachCube
   - MouseCube

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -28,12 +28,14 @@
     Biomass: 120
 
 # Start ADT Tweak
-- type: latheRecipe
-  parent: BaseCubeRecipe
-  id: ADTCubeGondola
-  result: ADTCubeGondola
-  materials:
-    Biomass: 120
+# Ganimed-Remove-Start
+#- type: latheRecipe
+#  parent: BaseCubeRecipe
+#  id: ADTCubeGondola
+#  result: ADTCubeGondola
+#  materials:
+#    Biomass: 120
+# Ganimed-Remove-End
 # End ADT Tweak
 
 - type: latheRecipe

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -851,3 +851,11 @@ ADTSpawnMobXenoRavager: SpawnMobXenoRavager
 # Ganimed 2026-01-24 (No roundstart energy dispensers)
 EnergyChemDispenser: ChemDispenser
 EnergyChemDispenserMachineCircuitboard: ChemDispenserMachineCircuitboard
+
+# Ganimed 2026-03-13
+MobArtificialHuman: MobMonkey
+ADTHumanCube: MonkeyCube
+ADTHumanCubeWrapped: MonkeyCubeWrapped
+ADTHumanCubeBox: MonkeyCubeBox
+ADTCubeGondola: MonkeyCube
+ADTPosterContrabandRoza: RandomPosterContraband


### PR DESCRIPTION
## Описание PR
Удалены кубики людей и гондолы, а также постер Розы с карт, заказов и рецептов.

## Технические детали
- Удалён рецепт `ADTCubeGondola` и заказ `LivestockArtificialHumanCube`.
- `MobArtificialHuman`, `ADTHumanCube`, `ADTHumanCubeWrapped`, `ADTHumanCubeBox` и `ADTCubeGondola` заменены на аналоги кубиков обезьян в migration.
- Шакальный 128-пиксельный `ADTPosterContrabandRoza` заменён на `RandomPosterContraband`.

<!-- ## Медиа -->

<!-- ## Чек-лист
- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [ ] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно. -->

## Список изменений
:cl: HyperB
- remove: Правительство ТСФ признало использование искусственных людей нелегальным. Nanotrasen уверяет, что никогда их не использовало.