### PR TITLE
[FIX] Sponsor

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1305,31 +1305,7 @@ namespace Content.Client.Lobby.UI
                 ReloadPreview();
             };
 
-            window.OnLoadoutPressedWithConflict += (loadoutGroup, loadoutProto, conflicts, conflictingGroups) => // Ganimed Sponsor start
-            {
-                var targetGroup = conflictingGroups.Values.First();
-
-                foreach (var conflictProto in conflicts)
-                {
-                    foreach (var (groupId, groupLoadouts) in roleLoadout.SelectedLoadouts)
-                    {
-                        if (groupLoadouts.Any(l => l.Prototype == conflictProto))
-                        {
-                            roleLoadout.RemoveLoadout(groupId, conflictProto, _prototypeManager);
-                            break;
-                        }
-                    }
-                }
-
-                roleLoadout.AddLoadout(targetGroup, loadoutProto, _prototypeManager);
-
-                window.RefreshLoadouts(roleLoadout, session, collection);
-                Profile = Profile?.WithLoadout(roleLoadout);
-                ReloadPreview();
-            };
-
             window.OnLoadoutUnpressed += (loadoutGroup, loadoutProto) =>
-            // Ganimed Sponsor end
             {
                 roleLoadout.RemoveLoadout(loadoutGroup, loadoutProto, _prototypeManager);
                 window.RefreshLoadouts(roleLoadout, session, collection);   // ADT SAI Custom tweaked

--- a/Content.Client/Lobby/UI/Loadouts/ILoadoutOverride.cs
+++ b/Content.Client/Lobby/UI/Loadouts/ILoadoutOverride.cs
@@ -8,7 +8,6 @@ namespace Content.Client.Lobby.UI.Loadouts;
 public interface ILoadoutOverride
 {
     public Action<KeyValuePair<string, string>>? OnValueChanged { get; set; }
-    public Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>, List<ProtoId<LoadoutPrototype>>, Dictionary<string, ProtoId<LoadoutGroupPrototype>>>? OnLoadoutPressedWithConflict { get; set; } // Ganimed Sponsor
     HumanoidCharacterProfile? Profile { get; set; }
 
     void Refresh(HumanoidCharacterProfile? profile, RoleLoadout loadout, IPrototypeManager protoMan);

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -28,7 +28,6 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
 
     public event Action<ProtoId<LoadoutPrototype>>? OnLoadoutPressed;
     public event Action<ProtoId<LoadoutPrototype>>? OnLoadoutUnpressed;
-    public event Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>, List<ProtoId<LoadoutPrototype>>, Dictionary<string, ProtoId<LoadoutGroupPrototype>>>? OnLoadoutPressedWithConflict; // Ganimed Sponsor
 
     public LoadoutGroupContainer(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutGroupPrototype groupProto, ICommonSession session, IDependencyCollection collection, bool isSponsor)
     {
@@ -278,58 +277,10 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
         cont.Select.OnPressed += args =>
         {
             if (args.Button.Pressed)
-            {
-                // Ganimed sponsor start
-                var allSlots = new HashSet<string>(proto.Equipment.Keys);
-                foreach (var storageSlot in proto.Storage.Keys)
-                {
-                    allSlots.Add(storageSlot);
-                }
-
-                var toRemove = new List<ProtoId<LoadoutPrototype>>();
-                var conflictingGroupForSlot = new Dictionary<string, ProtoId<LoadoutGroupPrototype>>();
-
-                foreach (var (groupId, groupLoadouts) in loadout.SelectedLoadouts)
-                {
-                    var resolvedLoadouts = groupLoadouts
-                        .Select(l => (Loadout: l, Proto: collection.Resolve<IPrototypeManager>().TryIndex(l.Prototype, out var p) ? p : null))
-                        .Where(x => x.Proto != null)!;
-
-                    foreach (var (selectedLoadout, selectedProto) in resolvedLoadouts)
-                    {
-                        foreach (var slot in allSlots)
-                        {
-                            var newHasSlot = proto.Equipment.ContainsKey(slot) || proto.Storage.ContainsKey(slot);
-                            var selectedHasEquipment = selectedProto!.Equipment.ContainsKey(slot);
-
-                            if (newHasSlot && selectedHasEquipment)
-                            {
-                                toRemove.Add(selectedLoadout.Prototype);
-
-                                if (!conflictingGroupForSlot.ContainsKey(slot))
-                                {
-                                    conflictingGroupForSlot[slot] = groupId;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (toRemove.Count > 0)
-                {
-                    OnLoadoutPressedWithConflict?.Invoke(_groupProto.ID, proto.ID, toRemove, conflictingGroupForSlot);
-                }
-                else
-                {
-                    OnLoadoutPressed?.Invoke(proto.ID);
-                }
-            }
+                OnLoadoutPressed?.Invoke(proto.ID);
             else
-            {
                 OnLoadoutUnpressed?.Invoke(proto.ID);
-            }
         };
-        // Ganimed sponsor end
 
         return cont;
     }

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutWindow.xaml.cs
@@ -21,7 +21,6 @@ public sealed partial class LoadoutWindow : BaseLoadoutWindow   // ADT SAI Custo
     public event Action<string>? OnNameChanged;
     public event Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>>? OnLoadoutPressed;
     public event Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>>? OnLoadoutUnpressed;
-    public event Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>, List<ProtoId<LoadoutPrototype>>, Dictionary<string, ProtoId<LoadoutGroupPrototype>>>? OnLoadoutPressedWithConflict; // Ganimed Sponsor
 
     private List<LoadoutGroupContainer> _groups = new();
 
@@ -91,12 +90,6 @@ public sealed partial class LoadoutWindow : BaseLoadoutWindow   // ADT SAI Custo
                 {
                     OnLoadoutUnpressed?.Invoke(group, args);
                 };
-                // Ganimed Sponsor start
-                container.OnLoadoutPressedWithConflict += (loadoutGroup, loadoutProto, conflicts, conflictingGroups) =>
-                {
-                    OnLoadoutPressedWithConflict?.Invoke(group, loadoutProto, conflicts, conflictingGroups);
-                };
-                // Ganimed Sponsor end
             }
         }
     }

--- a/Content.Client/Lobby/UI/Loadouts/StationAILoadoutWindow.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/StationAILoadoutWindow.xaml.cs
@@ -20,7 +20,6 @@ namespace Content.Client.Lobby.UI.Loadouts;
 public sealed partial class StationAILoadoutWindow : BaseLoadoutWindow, ILoadoutOverride
 {
     public Action<KeyValuePair<string, string>>? OnValueChanged { get; set; }
-    public Action<ProtoId<LoadoutGroupPrototype>, ProtoId<LoadoutPrototype>, List<ProtoId<LoadoutPrototype>>, Dictionary<string, ProtoId<LoadoutGroupPrototype>>>? OnLoadoutPressedWithConflict { get; set; } // Ganimed Sponsor
     public HumanoidCharacterProfile? Profile { get; set; }
     private SiliconLawsetPrototype? _lawset;
 

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -154,7 +154,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
 
                 // Malicious client maybe, check the group even has it.
                 // Ganimed Sponsor  start
-                bool isLoadoutInGroup = groupProto.Loadouts.Contains(loadout.Prototype);
+                bool isLoadoutInGroup = groupProto.ID == "Inventory" || groupProto.Loadouts.Contains(loadout.Prototype);
                 if (!isLoadoutInGroup)
                 {
                     if (!protoManager.TryIndex(loadout.Prototype, out _))
@@ -166,7 +166,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 }
 
                 // Validate the loadout can be applied (e.g. points).
-                if (!IsValid(profile, session, loadout.Prototype, collection, out _))
+                // Ganimed tweak: пропускаем IsValid для Inventory, т.к. элементы уже проверены через API
+                if (groupProto.ID != "Inventory" && !IsValid(profile, session, loadout.Prototype, collection, out _))
                 {
                     loadouts.RemoveAt(i);
                     continue;
@@ -207,6 +208,41 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
 
             SelectedLoadouts[group] = loadouts;
         }
+
+        // Ganimed Sponsor start
+        if (SelectedLoadouts.TryGetValue("Inventory", out var inventoryLoadouts))
+        {
+            var inventoryProtos = inventoryLoadouts
+                .Select(l => protoManager.TryIndex(l.Prototype, out var p) ? p : null)
+                .Where(p => p != null)!
+                .ToList();
+
+            foreach (var (groupId, groupLoadouts) in SelectedLoadouts.ToList())
+            {
+                if (groupId == "Inventory")
+                    continue;
+
+                for (var i = groupLoadouts.Count - 1; i >= 0; i--)
+                {
+                    var loadout = groupLoadouts[i];
+                    if (!protoManager.TryIndex(loadout.Prototype, out var loadoutProto))
+                        continue;
+
+                    foreach (var invProto in inventoryProtos)
+                    {
+                        if (invProto == null)
+                            continue;
+
+                        if (Conflicts(loadoutProto, invProto))
+                        {
+                            groupLoadouts.RemoveAt(i);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        // Ganimed Sponsor end
 
         foreach (var value in groupRemove)
         {
@@ -338,8 +374,27 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// </summary>
     public bool AddLoadout(ProtoId<LoadoutGroupPrototype> selectedGroup, ProtoId<LoadoutPrototype> selectedLoadout, IPrototypeManager protoManager)
     {
+        // Ganimed sponsor start
         if (!SelectedLoadouts.TryGetValue(selectedGroup, out var groupLoadouts))
             return false;
+
+        var newProto = protoManager.Index(selectedLoadout);
+
+        foreach (var (groupId, items) in SelectedLoadouts.ToList())
+        {
+            for (var i = items.Count - 1; i >= 0; i--)
+            {
+                var item = items[i];
+                if (!protoManager.TryIndex(item.Prototype, out var otherProto))
+                    continue;
+
+                if (Conflicts(newProto, otherProto))
+                {
+                    items.RemoveAt(i);
+                }
+            }
+        }
+        // Ganimed sponsor end
 
         groupLoadouts.Add(new Loadout()
         {
@@ -348,6 +403,19 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
 
         return true;
     }
+
+    // Ganimed sponsor start
+    private bool Conflicts(LoadoutPrototype a, LoadoutPrototype b)
+    {
+        foreach (var slot in a.Equipment.Keys)
+        {
+            if (b.Equipment.ContainsKey(slot))
+                return true;
+        }
+
+        return false;
+    }
+    // Ganimed sponsor end
 
     public bool RemoveLoadout(ProtoId<LoadoutGroupPrototype> selectedGroup, ProtoId<LoadoutPrototype> selectedLoadout, IPrototypeManager protoManager)
     {


### PR DESCRIPTION
## Описание PR
Исправлена работа личного инвентаря  в редакторе снаряжения. Ранее предметы из личного инвентаря слетали при сохранении и заменялись на стандартные предметы должности. Логика обработки конфликтов из коммита `5af080283a6a` (`OnLoadoutPressedWithConflict`) удаляла предметы из Inventory при выборе конфликтующих элементов из других групп. Также `EnsureValid` не очищал конфликты между группами при сохранении.

## Технические детали
1. `AddLoadout` - теперь удаляет **только конфликтующие элементы**, а не всю группу целиком (`items.Clear()` → `items.RemoveAt(i)`)
2. `EnsureValid` - добавлен проход удаления конфликтов с Inventory из других групп после основной валидации
3. `IsValid` - пропускается для Inventory (элементы уже проверены через API)
4. `isLoadoutInGroup` - пропускает проверку для Inventory (элементы приходят из API, а не из `groupProto.Loadouts`)

**Принцип работы:**
- Inventory имеет **абсолютный приоритет** - его элементы никогда не удаляются
- При выборе элемента из Inventory > `AddLoadout` находит конфликты по `Equipment` слотам → удаляет только конфликтующие элементы из других групп
- При сохранении > `EnsureValid` удаляет конфликты с Inventory из других групп

## Список изменений
:cl: CrimeMoot
- fix: Исправлена выдача спонсорских лодаутов.