### PR TITLE
[TWEAK] Rebalance things from ADT

### DIFF
--- a/Content.Client/ADT/Modsuits/UI/ModSuitMenu.xaml.cs
+++ b/Content.Client/ADT/Modsuits/UI/ModSuitMenu.xaml.cs
@@ -47,8 +47,13 @@ public sealed partial class ModSuitMenu : FancyWindow
 
         _buttonColors = modComp.ButtonColors;
 
+        // Ganimed-edit start
+        var attachedCount = _modsuit.GetAttachedToggleCount((_mod, modComp));
+        var displayRate = attachedCount > 0 ? modComp.ModEnergyBaseUsing : 0f;
+
         ModComplex.Text = Loc.GetString("mod-module-space", ("complexity", modComp.CurrentComplexity), ("maxcomplexity", modComp.MaxComplexity)) + Environment.NewLine +
-        Loc.GetString("mod-energy-waste", ("energy", modComp.ModEnergyBaseUsing.ToString("0.0")));
+        Loc.GetString("mod-energy-waste", ("energy", displayRate.ToString("0.0")));
+        // Ganimed-edit end
         var backpanelsStyle = new StyleBoxFlat(modComp.BackpanelsColor);
         var scrollStyle = new StyleBoxFlat(modComp.ScrollColor);
 

--- a/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Modules.cs
+++ b/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Modules.cs
@@ -149,12 +149,15 @@ public sealed partial class ModSuitSystem
             }
         }
 
+        // Ganimed-edit start
         if (TryComp<PowerCellDrawComponent>(suit, out var celldraw))
         {
             suit.Comp.ModEnergyBaseUsing = (float)Math.Round(suit.Comp.ModEnergyBaseUsing + module.Comp.EnergyUsing, 3);
             var attachedCount = GetAttachedToggleCount(suit);
-            celldraw.DrawRate = suit.Comp.ModEnergyBaseUsing * attachedCount;
+            if (attachedCount > 0)
+                celldraw.DrawRate = suit.Comp.ModEnergyBaseUsing;
         }
+        // Ganimed-edit end
     }
 
     public void DeactivateModule(Entity<ModSuitComponent> suit, Entity<ModSuitModComponent> module)
@@ -176,8 +179,7 @@ public sealed partial class ModSuitSystem
                 }
             }
 
-            module.Comp.Active = false;
-            UpdateUserInterface(suit, suit.Comp);
+            UpdateUserInterface(suit, suit.Comp); // Ganimed-tweak
 
             foreach (var attached in suit.Comp.ClothingUids)
             {
@@ -205,12 +207,15 @@ public sealed partial class ModSuitSystem
             }
         }
 
+        // Ganimed-edit start
         if (TryComp<PowerCellDrawComponent>(suit, out var celldraw))
         {
             suit.Comp.ModEnergyBaseUsing = (float)Math.Round(suit.Comp.ModEnergyBaseUsing - module.Comp.EnergyUsing, 3);
             var attachedCount = GetAttachedToggleCount(suit);
-            celldraw.DrawRate = suit.Comp.ModEnergyBaseUsing * attachedCount;
+            if (attachedCount > 0)
+                celldraw.DrawRate = suit.Comp.ModEnergyBaseUsing;
         }
+        // Ganimed-edit end
     }
 
     public string GetColor(ExamineColor color, string text)

--- a/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Suit.cs
+++ b/Content.Shared/ADT/Modsuit/Systems/ModSuitSystem.Suit.cs
@@ -397,8 +397,10 @@ public sealed partial class ModSuitSystem
         }
         else
         {
+            // Ganimed-edit start
             _cell.SetDrawEnabled(ent.Owner, true);
-            draw.DrawRate = ent.Comp.ModEnergyBaseUsing * attachedCount;
+            draw.DrawRate = ent.Comp.ModEnergyBaseUsing;
+            // Ganimed-edit end
         }
 
     }

--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.ftl
@@ -3,6 +3,6 @@ ent-ADTBulletLaser = лазерный заряд
 ent-ADTBulletDisabler = оглушающий заряд
 ent-BulletLaserHeavySpread = узкий лазерный залп
 ent-ADTBulletLaserGreenWeak = лазер
-ent-ADTBulletCutterWeak = пезак
+ent-ADTBulletCutterWeak = резак
 ent-ADTBulletDisablerStrong = оглушающий заряд
 ent-ADTBulletYellowLaser = электрический лазерный заряд

--- a/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.ftl
+++ b/Resources/Locale/ru-RU/ADT/prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.ftl
@@ -1,8 +1,8 @@
-ent-ADTBulletIon = Ионный заряд
-ent-ADTBulletLaser = Лазерный заряд
-ent-ADTBulletDisabler = Оглушающий заряд
-ent-BulletLaserHeavySpread = Узкий лазерный залп
-ent-ADTBulletLaserGreenWeak = Лазер
-ent-ADTBulletCutterWeak = Резак
-ent-ADTBulletDisablerStrong = Оглушающий заряд
-ent-ADTBulletYellowLaser = Электрический лазерный заряд
+ent-ADTBulletIon = ионный заряд
+ent-ADTBulletLaser = лазерный заряд
+ent-ADTBulletDisabler = оглушающий заряд
+ent-BulletLaserHeavySpread = узкий лазерный залп
+ent-ADTBulletLaserGreenWeak = лазер
+ent-ADTBulletCutterWeak = пезак
+ent-ADTBulletDisablerStrong = оглушающий заряд
+ent-ADTBulletYellowLaser = электрический лазерный заряд

--- a/Resources/Prototypes/ADT/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/ADT/Catalog/uplink_catalog.yml
@@ -710,15 +710,17 @@
 #       tags:
 #       - NukeOpsUplink
 
-- type: listing
-  id: ADTUplinkInvisibleCloak
-  name: uplink-invisible-cloak-name
-  description: uplink-invisible-cloak-desc
-  productEntity: ADTClothingNeckInvisibleCloak
-  cost:
-    Telecrystal: 5
-  categories:
-    - UplinkWearables
+# Ganimed-edit start
+# - type: listing
+#   id: ADTUplinkInvisibleCloak
+#   name: uplink-invisible-cloak-name
+#   description: uplink-invisible-cloak-desc
+#   productEntity: ADTClothingNeckInvisibleCloak
+#   cost:
+#     Telecrystal: 5
+#   categories:
+#     - UplinkWearables
+# Ganimed-edit end
 
 - type: listing
   id: ADTUplinkNightVision
@@ -736,7 +738,7 @@
   description: uplink-thermal-desc
   productEntity: ADTClothingEyesGlassesThermalChameleon
   cost:
-    Telecrystal: 2
+    Telecrystal: 5 # Ganimed-edit 2>5
   categories:
     - UplinkWearables
 

--- a/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
@@ -69,7 +69,7 @@
     enabled: false
     drawRate: 1
     useRate: 1
-    delay: 50
+    delay: 1 # Ganimed-tweak
   - type: PowerCellSlot
     cellSlotId: cell_slot
     fitsInCharger: false

--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -334,12 +334,10 @@
   - type: StaminaResistance
     damageCoefficient: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+    walkModifier: 0.9 # Ganimed-Edit
+    sprintModifier: 0.9 # Ganimed-Edit
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: FireProtection
-    reduction: 0.3
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -410,8 +408,6 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
-  - type: FireProtection
-    reduction: 0.7
   - type: ModifyGrabStageTime
     modifiers:
       Hard: 2.25
@@ -453,7 +449,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: FireProtection
-    reduction: 1
+    reduction: 0.8
   - type: ModifyGrabStageTime
     modifiers:
       Hard: 1.5

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Battery/battery_gun.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Battery/battery_gun.yml
@@ -234,8 +234,10 @@
       fireCost: 30
     - proto: ADTBulletLaser
       fireCost: 30
-    - proto: ADTBulletIon
-      fireCost: 90
+    # Ganimed-edit start
+    - proto: BulletTaser
+      fireCost: 200
+    # Ganimed-edit end
   - type: Battery
     maxCharge: 900
     startingCharge: 900

--- a/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -473,11 +473,15 @@
     impactEffect: ADTBulletImpactEffectIon
     damage:
       types:
-        Heat: 11
-        Shock: 4
+  # Ganimed-edit start
+        Heat: 7
+        Shock: 8
+  # Ganimed-edit end
     soundHit:
       collection: WeakHit
     forceSound: true
-  - type: EmpOnCollide
-    energyConsumption: 20
-    disableDuration: 2
+  # Ganimed-edit start
+  #- type: EmpOnCollide
+  #  energyConsumption: 20
+  #  disableDuration: 2
+  # Ganimed-edit end

--- a/Resources/Prototypes/ADT/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/ADT/Loadouts/Jobs/Medical/paramedic.yml
@@ -12,17 +12,17 @@
 - type: loadout
   id: ADTParamedicBackpack
   equipment:
-    back: ADTClothingBackpackParamedicFilled
+    back: ADTClothingBackpackParamedic # Ganimed-edit Криворукий гугу гага разраб АДТ, почему у тебя челюсти жизни привязаны к рюкзаку а не к самой роли?
 
 - type: loadout
   id: ADTParamedicSatchel
   equipment:
-    back: ADTClothingBackpackSatchelParamedicFilled
+    back: ADTClothingBackpackSatchelParamedic # Ganimed-edit
 
 - type: loadout
   id: ADTParamedicDuffel
   equipment:
-    back: ADTClothingBackpackDuffelParamedicFilled
+    back: ADTClothingBackpackDuffelParamedic # Ganimed-edit
 
 - type: loadout
   id: ADTParamedicBeltEMT

--- a/Resources/Prototypes/ADT/Reagents/medicine.yml
+++ b/Resources/Prototypes/ADT/Reagents/medicine.yml
@@ -492,7 +492,7 @@
   physicalDesc: reagent-physical-desc-murky
   flavor: medicine
   color: "#9575c7"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       metabolismRate : 0.75
@@ -519,7 +519,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#ff6d05"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       metabolismRate : 0.5
@@ -540,7 +540,7 @@
   physicalDesc: reagent-physical-desc-acrid
   flavor: medicine
   color: "#47061a"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       metabolismRate : 0.5
@@ -568,7 +568,7 @@
   physicalDesc: reagent-physical-desc-exotic-smelling
   flavor: medicine
   color: "#b315c2"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       metabolismRate : 0.5
@@ -595,7 +595,7 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: medicine
   color: "#111b30"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       metabolismRate : 0.5
@@ -669,7 +669,7 @@
   physicalDesc: reagent-physical-desc-sickly
   flavor: acid
   color: "#213200"
-  worksOnTheDead: true
+  worksOnTheDead: false # Ganimed-edit
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/ADT/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/Packs/medical.yml
@@ -22,7 +22,7 @@
   - ADTLauncherSyringe
   - ADTMiniSyringe
   - ADTTourniquet
-  - ADTPatchLepo
+  # - ADTPatchLepo Ganimed-edit
 
 - type: latheRecipePack
   id: ADTAdvancedMedical
@@ -45,11 +45,13 @@
 - type: latheRecipePack
   id: ADTCryoTech
   recipes:
-  - ADTPatchCryo
+  # - ADTPatchCryo Ganimed-edit
   - CryostasisBeaker
   - SyringeCryostasis
 
-- type: latheRecipePack
-  id: ADTThermoTech
-  recipes:
-  - ADTPatchThermo
+# Ganimed-edit start
+# - type: latheRecipePack
+#   id: ADTThermoTech
+#   recipes:
+#   - ADTPatchThermo
+# Ganimed-edit end

--- a/Resources/Prototypes/ADT/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/ADT/Recipes/Lathes/medical.yml
@@ -60,29 +60,31 @@
     Gold: 250
     Silver: 400
 
-- type: latheRecipe
-  id: ADTPatchLepo
-  result: ADTPatchLepo
-  completetime: 0.5
-  materials:
-    Copper: 20
-    Glass: 20
+# Ganimed-edit start
+# - type: latheRecipe
+#   id: ADTPatchLepo
+#   result: ADTPatchLepo
+#   completetime: 0.5
+#   materials:
+#     Copper: 20
+#     Glass: 20
 
-- type: latheRecipe
-  id: ADTPatchCryo
-  result: ADTPatchCryo
-  completetime: 0.5
-  materials:
-    Copper: 50
-    Glass: 100
+# - type: latheRecipe
+#   id: ADTPatchCryo
+#   result: ADTPatchCryo
+#   completetime: 0.5
+#   materials:
+#     Copper: 50
+#     Glass: 100
 
-- type: latheRecipe
-  id: ADTPatchThermo
-  result: ADTPatchThermo
-  completetime: 0.5
-  materials:
-    Copper: 100
-    Glass: 50
+# - type: latheRecipe
+#  id: ADTPatchThermo
+#  result: ADTPatchThermo
+#  completetime: 0.5
+#  materials:
+#    Copper: 100
+#    Glass: 50
+# Ganimed-edit end
 
 - type: latheRecipe
   id: ADTAutoSurgeon

--- a/Resources/Prototypes/ADT/Research/biochemical.yml
+++ b/Resources/Prototypes/ADT/Research/biochemical.yml
@@ -27,7 +27,7 @@
   recipeUnlocks:
   - StasisBedMachineCircuitboard
   - ADTAdvancedMedicalBedCircuitboard
-  - ADTPatchLepo
+# - ADTPatchLepo Ganimed-edit
   - MedicalScannerMachineCircuitboard
   position: 3,-1
   requiredTech:
@@ -61,8 +61,12 @@
   - CloningPodMachineCircuitboard
   - CloningConsoleComputerCircuitboard
   position: 1,-1
+# Ganimed-edit start
+#  requiredTech:
+#  - ADTThermoTech Почему оно вообще требует технологию пластырей, а не крио, хоть в консоли и отображается требование технологии крио???
   requiredTech:
-  - ADTThermoTech
+  - ADTCryoTech
+# Ganimed-end
 
 - type: technology
   id: ADTIndustrialMedicine
@@ -110,25 +114,27 @@
   - CryoPodMachineCircuitboard
   - CryostasisBeaker
   - SyringeCryostasis
-  - ADTPatchCryo
+# - ADTPatchCryo Ganimed-edit
   requiredTech:
   - ADTAdvancedMedicalCare
   position: 2,-2
 
-- type: technology
-  id: ADTThermoTech
-  name: research-technology-thermo
-  icon:
-    sprite: ADT/Objects/Specific/Medical/patch.rsi
-    state: patch23
-  discipline: Biochemical
-  tier: 3
-  cost: 7500
-  recipeUnlocks:
-  - ADTPatchThermo
-  requiredTech:
-  - ADTCryoTech
-  position: 2,0
+# Ganimed-edit start
+#- type: technology
+#  id: ADTThermoTech
+#  name: research-technology-thermo
+#  icon:
+#    sprite: ADT/Objects/Specific/Medical/patch.rsi
+#    state: patch23
+#  discipline: Biochemical
+#  tier: 3
+#  cost: 7500
+#  recipeUnlocks:
+#  - ADTPatchThermo
+#  requiredTech:
+#  - ADTCryoTech
+#  position: 2,0
+# Ganimed-edit end
 
 - type: technology
   id: ADTMechanizedTreatment

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1135,12 +1135,6 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitDeathsquad
-  # ADT-Tweak-start
-  - type: ClothingGrantComponent
-    component:
-    - type: SupermatterImmune
-  - type: SupermatterImmune
-  # ADT-Tweak-end
 
 #CBURN Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -563,7 +563,6 @@
     - ADTAdvancedMedicalMiscPack
     - ADTAdvancedMedicalCarePack
     - ADTCryoTech
-    - ADTThermoTech
     #ADT-Tweak End
   - type: Machine
     board: MedicalTechFabCircuitboard

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -201,7 +201,6 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
-  worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -224,10 +223,10 @@
           damage:
           # todo scale with temp like SS13
           # ADT-Tweak start (made HealthChange even)
-            Airloss: -1
-            Brute: -1
-            Burn: -1.2
-            Toxin: -0.8
+            Airloss: -3
+            Brute: -2
+            Burn: -2
+            Toxin: -2
           # ADT-Tweak end
         # Start ADT tweak
         - !type:HealthChange
@@ -253,7 +252,6 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
-  worksOnTheDead: true
   metabolisms:
     Medicine:
       effects:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -58,29 +58,25 @@
   id: Cryoxadone
   maxTemp: 175 # ADT tweak
   reactants:
-    Tricordrazine: # ADT tweak Не, нафиг растения для крио --QWERTY--(Может сделать новое особое растение для крио, но это лишь в планах
+    Dexalin:
       amount: 1
-    DexalinPlus: # ADT tweak
-      amount: 2 # ADT tweak
     Water:
-      amount: 2 # ADT tweak
+      amount: 1
+    Oxygen:
+      amount: 1
   products:
-    Cryoxadone: 5 # ADT tweak
+    Cryoxadone: 3
 
 - type: reaction
   id: Doxarubixadone
   maxTemp: 150 # ADT tweak
   reactants:
-  # ADT tweak Start
     Cryoxadone:
       amount: 1
     UnstableMutagen:
       amount: 1
-    Phalanximine:
-      amount: 2
-  # ADT tweak End
   products:
-    Doxarubixadone: 4 # ADT tweak
+    Doxarubixadone: 2
 
 - type: reaction
   id: Epinephrine

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -12,7 +12,7 @@
   startingGear: ParamedicGear
   icon: "JobIconParamedic"
   supervisors: job-supervisors-cmo
-  canBeAntag: false # ADT tweak?
+  canBeAntag: true
   access:
   - Medical
   - Maintenance


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. Вы можете редактировать этот шаблон PRа, добавляя, убирая или изменяя его пункты и подпункты, по необходимости. -->

## Описание PR
Теперь все АДТшные модсьюты имеют резисты их версий скафандров.

Скафандр дед сквада больше не имеет защиты от суперматерии. Защита от СМа у дедов забирает уйму смешных моментов, как они из-за тупости умирают об СМ. Оказуаливание ради оказуаливания.

Удален плащ-невидимка из аплинка синдиката. Имеет стоимость коробки-невидимки, но при этом всегда с тобой, из инвиза не приходится выходить, а по РП все делают вид, что не видят тебя, поэтому малая видимость это никак не балансит.

X-01 ГСБ был убран режим ионной пушки, вместо этого ему был добавлен режим тазера. Раундстарт оружие, имеющее возможность убивать с одного выстрела КПБ, боргов синдиката и боевых мехов это очень имбалансно.

Летальному режиму CC-7 Арбитра был убран ЭМИ импульс при выстреле, но при этом он имеет больше урона от электричества. Причина такая-же как и у X-01

Парамедику были убраны челюсти жизни, а также теперь он может стать антагом. В будущем ему будут добавлены челюсти жизни, которые не могут открывать шлюзы командования и СБ, как на ТГ.

Все крио-лекарства кроме некрозола более не действует на мертвых. Теперь получил 190 яда или 190 радиации тебя будет сложнее вылечить, убираем лишнее оказуаливание и делаем клонерку более полезной.

Рецепт криоксадона и доксурубиксадона теперь как на визденах, без понятия почему их рецепт до этого был таким дорогим, учитывая что криоксадон необходим для ботаников и других реагентов.

Криоксадон теперь лечит как раньше. Без понятия зачем его нерфили.

Удалены патчи изменяющие температуру из РНД. Патчи являются респрайтом медипена, из-за чего ты за два клика моментально можешь убить человека холодом/жаром.

Теперь МОДы корректно потребляют энергию. Раньше сжирали всю батарею за 5 минут, теперь с включенным модулем хранилища обычной батареи хватает на 20 минут. Я пофиксил все ошибки в коде, которые вызывали чрезмерное потребление энергии

## Технические детали
Все проджектайлы в файле локализации теперь начинаются с маленькой буквы, т.к все остальные тоже с маленькой буквы.

Также я убрал умножение энергопотребления на количество модулей, то есть, если у тебя было включено 5 модулей, то МОД потреблял не только увеличенное потреблени от самих модулей, но и само потребление умножалось на пять. Обновление энергопотребления теперь происходит каждую секунду, а не раз в 50 секунд. Добавлена проверка if (attachedCount > 0) — обновление DrawRate происходит только когда хотя бы одна часть МОДа надета. Удалена лишняя строка внутри if (_netMan.IsServer).

## Чек-лист
- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [X] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно. 

## Список изменений
:cl: Gorox
- fix: МОДсьюты теперь корректно потребляют энергию. Обычной батареи хватает на 20 минут, а не на 5 как раньше.
- remove: Удалены все пластыри изменяющие температуру тела из исследований РНД.
- remove: Удален плащ-невидимка из аплинка синдиката.
- tweak: Скафандры эскадрона смерти больше не защищают от суперматерии.
- tweak: X-01 более не имеет ионного режима стрельбы, вместо этого ему был добавлен режим стрельбы тазера.
- tweak: Летальному режиму CC-7 Арбитра был убран ЭМИ импульс при выстреле, но при этом он теперь имеет больше урона от электричества.
- tweak: Парамедик больше не появляется с челюстями жизни в начале раунда.
- tweak: Парамедик вновь может стать антагонистом.
- tweak: Лекарства из крио, кроме некрозола больше не действуют на мертвых.
- tweak: Рецепт криоксадона и доксурубиксадона теперь соответствует рецепту с ванильной сборки игры. Криоксадон = Дексалин + Вода + Кислород. Доксурибиксадон = Криоксадон + Нестабильный мутаген.
- tweak: Криоксадон теперь лечит как раньше. Механический урон: 1 -> 2 Ожоги: 1.2 -> 2 Токсины: 0.8 -> 2 Удушье: 1 -> 3.