### PR TITLE
Фикс турелей, стреляющих в нераскрытых антагов (#351)

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/TraitorRuleTest.cs
@@ -125,8 +125,10 @@ public sealed class TraitorRuleTest
         // Make sure the player is a traitor.
         var mind = mindSys.GetMind(player)!.Value;
         Assert.That(roleSys.MindIsAntagonist(mind));
-        Assert.That(factionSys.IsMember(player, SyndicateFaction), Is.True);
-        Assert.That(factionSys.IsMember(player, NanotrasenFaction), Is.False);
+        // Ganimed-Edit: traitors keep the NanoTrasen faction on selection, so faction-based
+        // NPCs/turrets (hostile to "Syndicate") don't attack unrevealed antags.
+        Assert.That(factionSys.IsMember(player, SyndicateFaction), Is.False);
+        Assert.That(factionSys.IsMember(player, NanotrasenFaction), Is.True);
         Assert.That(traitorRule.TotalTraitors, Is.EqualTo(1));
         Assert.That(traitorRule.TraitorMinds[0], Is.EqualTo(mind));
 

--- a/Content.Server/ADT/GameTicking/Rules/ChangelingRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/ChangelingRuleSystem.cs
@@ -2,6 +2,9 @@ using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Shared.Changeling.Components;
+// Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+// using Content.Shared.NPC.Systems;
+// using Content.Shared.NPC.Prototypes;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Tag;
 using Content.Shared.Roles;
@@ -16,10 +19,16 @@ public sealed partial class ChangelingRuleSystem : GameRuleSystem<ChangelingRule
 {
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
+    // Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+    // [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _userInterfaceSystem = default!;
 
+    // Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+    // public readonly ProtoId<NpcFactionPrototype> SyndicateFactionId = "Syndicate";
+    //
+    // public readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
     [ValidatePrototypeId<CurrencyPrototype>] public readonly ProtoId<CurrencyPrototype> Currency = "EvolutionPoints";
 
     public override void Initialize()
@@ -61,8 +70,13 @@ public sealed partial class ChangelingRuleSystem : GameRuleSystem<ChangelingRule
             _userInterfaceSystem.SetUi(target, StoreUiKey.Key, new InterfaceData("StoreBoundUserInterface"));
         }
 
-        // Ganimed-Edit: removed the faction swap here. The changeling keeps the NanoTrasen faction until
-        // revealed, so faction-based NPCs/turrets (hostile to "Syndicate") don't attack unrevealed antags.
+        // Ganimed-Edit (issue #351): faction swap removed. The changeling used to be moved from the
+        // NanoTrasen faction to Syndicate right on selection, which made station turrets/NPCs (hostile
+        // to "Syndicate") shoot unrevealed antags. The changeling now keeps the NanoTrasen faction.
+        // _npcFaction.RemoveFaction(target, NanotrasenFactionId, false);
+        // _npcFaction.AddFaction(target, SyndicateFactionId);
+        //
+        // Ensure Changeling component and role
         EnsureComp<ChangelingComponent>(target);
 
         rule.Minds.Add(mindId);

--- a/Content.Server/ADT/GameTicking/Rules/ChangelingRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/ChangelingRuleSystem.cs
@@ -2,8 +2,6 @@ using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Mind;
 using Content.Shared.Changeling.Components;
-using Content.Shared.NPC.Systems;
-using Content.Shared.NPC.Prototypes;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Tag;
 using Content.Shared.Roles;
@@ -18,14 +16,10 @@ public sealed partial class ChangelingRuleSystem : GameRuleSystem<ChangelingRule
 {
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _userInterfaceSystem = default!;
 
-    public readonly ProtoId<NpcFactionPrototype> SyndicateFactionId = "Syndicate";
-
-    public readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
     [ValidatePrototypeId<CurrencyPrototype>] public readonly ProtoId<CurrencyPrototype> Currency = "EvolutionPoints";
 
     public override void Initialize()
@@ -67,10 +61,8 @@ public sealed partial class ChangelingRuleSystem : GameRuleSystem<ChangelingRule
             _userInterfaceSystem.SetUi(target, StoreUiKey.Key, new InterfaceData("StoreBoundUserInterface"));
         }
 
-        _npcFaction.RemoveFaction(target, NanotrasenFactionId, false);
-        _npcFaction.AddFaction(target, SyndicateFactionId);
-
-        // Ensure Changeling component and role
+        // Ganimed-Edit: removed the faction swap here. The changeling keeps the NanoTrasen faction until
+        // revealed, so faction-based NPCs/turrets (hostile to "Syndicate") don't attack unrevealed antags.
         EnsureComp<ChangelingComponent>(target);
 
         rule.Minds.Add(mindId);

--- a/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
@@ -6,6 +6,9 @@ using Content.Server.Objectives;
 using Content.Server.Objectives.Components;
 using Content.Server.Roles;
 using Content.Shared.Heretic;
+// Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+// using Content.Shared.NPC.Prototypes;
+// using Content.Shared.NPC.Systems;
 using Content.Shared.Roles;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
@@ -24,12 +27,19 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
+    // Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+    // [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly ObjectivesSystem _objective = default!;
     [Dependency] private readonly IRobustRandom _rand = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _userInterfaceSystem = default!;
 
 
     public readonly SoundSpecifier BriefingSound = new SoundPathSpecifier("/Audio/ADT/Heretic/Ambience/Antag/Heretic/heretic_gain.ogg");
+
+    // Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+    // [ValidatePrototypeId<NpcFactionPrototype>] public readonly ProtoId<NpcFactionPrototype> HereticFactionId = "Heretic";
+    //
+    // [ValidatePrototypeId<NpcFactionPrototype>] public readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
 
     [ValidatePrototypeId<CurrencyPrototype>] public readonly ProtoId<CurrencyPrototype> Currency = "KnowledgePoint";
 
@@ -74,8 +84,12 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
             _antag.SendBriefing(target, Loc.GetString("heretic-role-greeting"), Color.Red, BriefingSound);
 
         }
-        // Ganimed-Edit: removed the faction swap here. The heretic keeps the NanoTrasen faction until
-        // revealed, so faction-based NPCs/turrets (hostile to "Heretic") don't attack unrevealed antags.
+        // Ganimed-Edit (issue #351): faction swap removed. The heretic used to be moved from the
+        // NanoTrasen faction to Heretic right on selection, which made station turrets/NPCs (hostile
+        // to "Heretic") shoot unrevealed antags. The heretic now keeps the NanoTrasen faction.
+        // _npcFaction.RemoveFaction(target, NanotrasenFactionId, false);
+        // _npcFaction.AddFaction(target, HereticFactionId);
+        //
         EnsureComp<HereticComponent>(target);
 
         // add store

--- a/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
+++ b/Content.Server/ADT/GameTicking/Rules/HereticRuleSystem.cs
@@ -6,8 +6,6 @@ using Content.Server.Objectives;
 using Content.Server.Objectives.Components;
 using Content.Server.Roles;
 using Content.Shared.Heretic;
-using Content.Shared.NPC.Prototypes;
-using Content.Shared.NPC.Systems;
 using Content.Shared.Roles;
 using Content.Shared.Store;
 using Content.Shared.Store.Components;
@@ -26,17 +24,12 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly ObjectivesSystem _objective = default!;
     [Dependency] private readonly IRobustRandom _rand = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _userInterfaceSystem = default!;
 
 
     public readonly SoundSpecifier BriefingSound = new SoundPathSpecifier("/Audio/ADT/Heretic/Ambience/Antag/Heretic/heretic_gain.ogg");
-
-    [ValidatePrototypeId<NpcFactionPrototype>] public readonly ProtoId<NpcFactionPrototype> HereticFactionId = "Heretic";
-
-    [ValidatePrototypeId<NpcFactionPrototype>] public readonly ProtoId<NpcFactionPrototype> NanotrasenFactionId = "NanoTrasen";
 
     [ValidatePrototypeId<CurrencyPrototype>] public readonly ProtoId<CurrencyPrototype> Currency = "KnowledgePoint";
 
@@ -81,9 +74,8 @@ public sealed partial class HereticRuleSystem : GameRuleSystem<HereticRuleCompon
             _antag.SendBriefing(target, Loc.GetString("heretic-role-greeting"), Color.Red, BriefingSound);
 
         }
-        _npcFaction.RemoveFaction(target, NanotrasenFactionId, false);
-        _npcFaction.AddFaction(target, HereticFactionId);
-
+        // Ganimed-Edit: removed the faction swap here. The heretic keeps the NanoTrasen faction until
+        // revealed, so faction-based NPCs/turrets (hostile to "Heretic") don't attack unrevealed antags.
         EnsureComp<HereticComponent>(target);
 
         // add store

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Codewords;
 using Content.Shared.Dataset;
 using Content.Shared.FixedPoint;
+using Content.Shared.NPC.Prototypes; // Ganimed-Edit: kept - NanoTrasenFaction/SyndicateFaction fields remain (per review)
 using Content.Shared.Random;
 using Content.Shared.Roles;
 using Robust.Shared.Audio;
@@ -20,7 +21,16 @@ public sealed partial class TraitorRuleComponent : Component
     [DataField]
     public ProtoId<CodewordFactionPrototype> CodewordFactionPrototypeId = "Traitor";
 
-    [DataField] // Ganimed-Edit: NanoTrasenFaction/SyndicateFaction removed - traitors no longer change faction on selection
+    // Ganimed-Edit (issue #351): kept per review - "no field removals in vanilla components".
+    // No longer used: the traitor no longer changes faction on selection, so turrets/NPCs
+    // hostile to "Syndicate" don't attack unrevealed antags.
+    [DataField]
+    public ProtoId<NpcFactionPrototype> NanoTrasenFaction = "NanoTrasen";
+
+    [DataField]
+    public ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
+
+    [DataField]
     public ProtoId<LocalizedDatasetPrototype> ObjectiveIssuers = "TraitorCorporations";
 
     /// <summary>

--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -1,7 +1,6 @@
 using Content.Server.Codewords;
 using Content.Shared.Dataset;
 using Content.Shared.FixedPoint;
-using Content.Shared.NPC.Prototypes;
 using Content.Shared.Random;
 using Content.Shared.Roles;
 using Robust.Shared.Audio;
@@ -21,13 +20,7 @@ public sealed partial class TraitorRuleComponent : Component
     [DataField]
     public ProtoId<CodewordFactionPrototype> CodewordFactionPrototypeId = "Traitor";
 
-    [DataField]
-    public ProtoId<NpcFactionPrototype> NanoTrasenFaction = "NanoTrasen";
-
-    [DataField]
-    public ProtoId<NpcFactionPrototype> SyndicateFaction = "Syndicate";
-
-    [DataField]
+    [DataField] // Ganimed-Edit: NanoTrasenFaction/SyndicateFaction removed - traitors no longer change faction on selection
     public ProtoId<LocalizedDatasetPrototype> ObjectiveIssuers = "TraitorCorporations";
 
     /// <summary>

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
-using Content.Shared.NPC.Systems;
 using Content.Shared.PDA;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Roles;
@@ -28,7 +27,6 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly SharedJobSystem _jobs = default!;
     [Dependency] private readonly MindSystem _mindSystem = default!;
-    [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedRoleCodewordSystem _roleCodewordSystem = default!;
@@ -135,11 +133,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         var codewordComp = EnsureComp<RoleCodewordComponent>(mindId);
         _roleCodewordSystem.SetRoleCodewords((mindId, codewordComp), "traitor", factionCodewords.ToList(), color);
 
-        // Change the faction
-        Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Change faction");
-        _npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
-        _npcFaction.AddFaction(traitor, component.SyndicateFaction);
-
+        // Ganimed-Edit: removed the faction swap below. The traitor keeps the NanoTrasen faction until
+        // revealed, so faction-based NPCs/turrets (hostile to "Syndicate") don't attack unrevealed antags.
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Finished");
         return true;
     }

--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -6,6 +6,8 @@ using Content.Server.PDA.Ringer;
 using Content.Server.Traitor.Uplink;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mind;
+// Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+// using Content.Shared.NPC.Systems;
 using Content.Shared.PDA;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Roles;
@@ -27,6 +29,8 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly SharedJobSystem _jobs = default!;
     [Dependency] private readonly MindSystem _mindSystem = default!;
+    // Ganimed-Edit: removed - faction swap no longer performed (issue #351)
+    // [Dependency] private readonly NpcFactionSystem _npcFaction = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedRoleCodewordSystem _roleCodewordSystem = default!;
@@ -133,8 +137,16 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
         var codewordComp = EnsureComp<RoleCodewordComponent>(mindId);
         _roleCodewordSystem.SetRoleCodewords((mindId, codewordComp), "traitor", factionCodewords.ToList(), color);
 
-        // Ganimed-Edit: removed the faction swap below. The traitor keeps the NanoTrasen faction until
-        // revealed, so faction-based NPCs/turrets (hostile to "Syndicate") don't attack unrevealed antags.
+        // Ganimed-Edit (issue #351): faction swap removed. The traitor used to be moved from the
+        // NanoTrasen faction to Syndicate right on selection, which made station turrets/NPCs (hostile
+        // to "Syndicate") shoot unrevealed antags. The traitor now keeps the NanoTrasen faction.
+        // The "reveal" is effectively the antag's own actions (crimes) - nothing in code marks them
+        // as an enemy until then; before this fix the faction swap itself was the "reveal".
+        // Change the faction
+        // Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Change faction");
+        // _npcFaction.RemoveFaction(traitor, component.NanoTrasenFaction, false);
+        // _npcFaction.AddFaction(traitor, component.SyndicateFaction);
+        //
         Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Finished");
         return true;
     }

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -266,6 +266,7 @@
   components:
   - type: GameRule
     minPlayers: 25
+  - type: ChangelingRule # Ganimed-Edit: added so changelings are actually made via ChangelingRuleSystem (was missing, breaking the whole antag)
   - type: AntagSelection
     agentName: changeling-round-end-agent-name
     selectionTime: IntraPlayerSpawn

--- a/Resources/Prototypes/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/Roles/Antags/changeling.yml
@@ -2,5 +2,5 @@
   id: Changeling
   name: roles-antag-changeling-name
   antagonist: true
-  setPreference: false # TODO: set this to true once Changeling exits WIP status
+  setPreference: true # Ganimed-Edit: enabled so players can opt into Changeling; without it the pref is stripped on profile save and the antag can never be picked
   objective: roles-antag-changeling-objective


### PR DESCRIPTION
## Описание PR

Фикс ишью #351. Турели и NPC с враждебными фракциями стреляли в нераскрытых антагов, потому что при назначении антага менялась фракция: еретик получал Heretic, генокрад и предатель Syndicate. Фракция NanoTrasen считает их врагами, поэтому турель сразу открывала огонь и палила антага.

Теперь еретик, генокрад и предатель остаются во фракции NanoTrasen, пока не раскрыты. Турели, враждебные всем (SimpleHostile, AllHostile, Syndicate, Xeno), по-прежнему стреляют, как и в любого члена экипажа.

## Технические детали

- убрал смену фракции в HereticRuleSystem, ChangelingRuleSystem и TraitorRuleSystem
- убрал неиспользуемые поля фракций (HereticFactionId, SyndicateFactionId и т.д.) и зависимости NpcFactionSystem
- заодно починил генокрада: в геймрул Changeling не было компонента ChangelingRule, из-за чего TryMakeChangeling вообще не вызывался и генокрадов нельзя было назначить. Добавил компонент и включил setPreference у антага Changeling (без него преф стирается при сохранении профиля и игрока не выбрать)
- обновил TraitorRuleTest: теперь проверяет, что предатель остаётся в NanoTrasen

## Медиа

Нет.

## Чек-лист

- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [X] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений

:cl: ultradyper
- fix: Турели больше не атакуют нераскрытых еретиков, генокрадов и предателей
- fix: Генокрадов теперь можно назначить (не было компонента геймрула, антаг не работал)
