### PR TITLE
AI Private канал, синтетический обход вендоматов, радиал турелей и ЛКП (#208)

### DIFF
--- a/Content.Client/ADT/VendingMachines/UI/FancyVendingMachineMenu.xaml
+++ b/Content.Client/ADT/VendingMachines/UI/FancyVendingMachineMenu.xaml
@@ -14,6 +14,12 @@
                 Text="{Loc 'store-ui-default-withdraw-text'}"
                 Margin ="4 4"
                 HorizontalAlignment="Right"/>
+            <Button
+                Name="SyntheticBypassButton"
+                Text="{Loc 'vending-machine-synthetic-bypass'}"
+                Margin ="4 4"
+                HorizontalAlignment="Right"
+                Visible="False"/> <!-- Ganimed-Edit: AI synthetic bypass (issue #208) -->
             <LineEdit Name="SearchBar" PlaceHolder="{Loc 'vending-machine-component-search-filter'}" HorizontalExpand="True" Margin ="4 4"/>
         </BoxContainer>
         <cc:HSeparator Margin="8 8 8 0" />

--- a/Content.Client/ADT/VendingMachines/UI/FancyVendingMachineMenu.xaml.cs
+++ b/Content.Client/ADT/VendingMachines/UI/FancyVendingMachineMenu.xaml.cs
@@ -31,6 +31,8 @@ public sealed partial class FancyVendingMachineMenu : FancyWindow
 
     public event Action<VendingMachineInventoryEntry>? OnItemSelected;
     public Action? OnWithdraw;
+    // Ganimed-Edit: AI synthetic bypass (issue #208)
+    public Action? OnSyntheticBypass;
 
     private double _priceMultiplier = 1;
 
@@ -53,6 +55,27 @@ public sealed partial class FancyVendingMachineMenu : FancyWindow
 
         SearchBar.OnTextChanged += _ => PopulateList();
         WithdrawButton.OnPressed += _ => OnWithdraw?.Invoke();
+        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        SyntheticBypassButton.OnPressed += _ => OnSyntheticBypass?.Invoke();
+    }
+
+    // Ganimed-Edit: AI synthetic bypass (issue #208)
+    public bool SyntheticBypassVisible
+    {
+        set => SyntheticBypassButton.Visible = value;
+    }
+
+    /// <summary>
+    /// Updates the synthetic bypass button. <paramref name="cooldownRemaining"/> is in seconds.
+    /// </summary>
+    public void UpdateSyntheticBypass(bool armed, int cooldownRemaining)
+    {
+        SyntheticBypassButton.Disabled = armed || cooldownRemaining > 0;
+        SyntheticBypassButton.Text = Loc.GetString(armed
+            ? "vending-machine-synthetic-bypass-armed"
+            : cooldownRemaining > 0
+                ? "vending-machine-synthetic-bypass-cooldown"
+                : "vending-machine-synthetic-bypass", ("time", cooldownRemaining));
     }
 
     /// <summary>

--- a/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
+++ b/Content.Client/VendingMachines/VendingMachineBoundUserInterface.cs
@@ -1,7 +1,9 @@
 using Content.Client.ADT.VendingMachines.UI;
 using Content.Client.UserInterface.Controls;
 using Content.Client.VendingMachines.UI;
+using Content.Shared.Silicons.StationAi; // Ganimed-Edit: AI synthetic bypass (issue #208)
 using Content.Shared.VendingMachines;
+using Robust.Client.Player; // Ganimed-Edit: AI synthetic bypass (issue #208)
 using Robust.Client.UserInterface;
 using Robust.Shared.Input;
 using System.Linq;
@@ -34,6 +36,10 @@ namespace Content.Client.VendingMachines
             _menu.OnClose += Close;
             _menu.OnItemSelected += OnItemSelected;
             _menu.OnWithdraw += () => SendMessage(new VendingMachineWithdrawMessage());
+            // Ganimed-Edit: AI synthetic bypass (issue #208)
+            _menu.OnSyntheticBypass += () => SendMessage(new VendingMachineSyntheticBypassMessage());
+            _menu.SyntheticBypassVisible = IoCManager.Resolve<IPlayerManager>().LocalEntity is { } localPlayer &&
+                EntMan.HasComponent<StationAiHeldComponent>(localPlayer);
             _menu.Populate(Owner, _cachedInventory, component.PriceMultiplier, component.Credits);
             // ADT-tweak-end
 
@@ -71,6 +77,8 @@ namespace Content.Client.VendingMachines
             _cachedInventory = system.GetAllInventory(Owner);
 
             _menu?.Populate(Owner, _cachedInventory, newState.PriceMultiplier, newState.Credits); //ADT-Economy-Tweak
+            // Ganimed-Edit: AI synthetic bypass (issue #208)
+            _menu?.UpdateSyntheticBypass(newState.SyntheticBypassArmed, newState.SyntheticBypassCooldownRemaining);
         }
 
         private void OnItemSelected(VendingMachineInventoryEntry entry)

--- a/Content.Client/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
+++ b/Content.Client/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Client.Power.APC;
+using Content.Shared._Ganimed.Silicons.StationAi.Systems;
+using Content.Shared.Silicons.StationAi;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Ganimed.Silicons.StationAi;
+
+/// <summary>
+/// Adds a radial menu action for APCs controlled by the station AI.
+/// </summary>
+public sealed partial class StationAiApcRadialSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ApcVisualsComponent, GetStationAiRadialEvent>(OnGetRadial);
+    }
+
+    private void OnGetRadial(Entity<ApcVisualsComponent> ent, ref GetStationAiRadialEvent args)
+    {
+        args.Actions.Add(new StationAiRadial
+        {
+            Sprite = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Tooltip = Loc.GetString("ai-apc-toggle-breaker"),
+            Event = new StationAiApcToggleBreakerEvent(),
+        });
+    }
+}

--- a/Content.Client/_Ganimed/Silicons/StationAi/StationAiRadialTurretSystem.cs
+++ b/Content.Client/_Ganimed/Silicons/StationAi/StationAiRadialTurretSystem.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared._Ganimed.Silicons.StationAi.Systems;
+using Content.Shared.Silicons.StationAi;
+using Content.Shared.Turrets;
+using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Client._Ganimed.Silicons.StationAi;
+
+/// <summary>
+/// Adds radial menu actions for AI-controlled turrets.
+/// </summary>
+public sealed partial class StationAiRadialTurretSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StationAiTurretComponent, GetStationAiRadialEvent>(OnGetRadial);
+    }
+
+    private void OnGetRadial(Entity<StationAiTurretComponent> ent, ref GetStationAiRadialEvent args)
+    {
+        if (!TryComp(ent.Owner, out DeployableTurretComponent? deployable))
+            return;
+
+        args.Actions.Add(new StationAiRadial
+        {
+            Sprite = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Tooltip = deployable.Enabled
+                ? Loc.GetString("ai-turret-disable")
+                : Loc.GetString("ai-turret-enable"),
+            Event = new StationAiTurretToggleEvent
+            {
+                Enabled = !deployable.Enabled,
+            }
+        });
+
+        if (!TryComp(ent.Owner, out BatteryWeaponFireModesComponent? fireModes) || fireModes.FireModes.Count < 2)
+            return;
+
+        var nextIndex = (fireModes.CurrentFireMode + 1) % fireModes.FireModes.Count;
+        var nextProtoId = fireModes.FireModes[nextIndex].Prototype;
+
+        if (!_proto.TryIndex(nextProtoId, out EntityPrototype? nextProto))
+            return;
+
+        args.Actions.Add(new StationAiRadial
+        {
+            Sprite = new SpriteSpecifier.Texture(new ResPath("/Textures/Interface/VerbIcons/point.svg.192dpi.png")),
+            Tooltip = nextProto.Name,
+            Event = new StationAiTurretCycleFireModeEvent(),
+        });
+    }
+}

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -35,6 +35,9 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
     // Used to prevent a shitter from using a bunch of radios to spam chat.
     private HashSet<(string, EntityUid, RadioChannelPrototype)> _recentlySent = new();
 
+    // Ganimed-Edit: channel supported by every intercom (issue #208)
+    private static readonly ProtoId<RadioChannelPrototype> _aiPrivateChannel = "AiPrivate";
+
     public override void Initialize()
     {
         base.Initialize();
@@ -206,6 +209,10 @@ public sealed class RadioDeviceSystem : SharedRadioDeviceSystem
     private void OnIntercomEncryptionChannelsChanged(Entity<IntercomComponent> ent, ref EncryptionChannelsChangedEvent args)
     {
         ent.Comp.SupportedChannels = args.Component.Channels.Select(p => new ProtoId<RadioChannelPrototype>(p)).ToList();
+
+        // Ganimed-Edit: intercoms always support the AI private channel (issue #208)
+        if (!ent.Comp.SupportedChannels.Contains(_aiPrivateChannel))
+            ent.Comp.SupportedChannels.Add(_aiPrivateChannel);
 
         var channel = args.Component.DefaultChannel;
         if (ent.Comp.CurrentChannel != null && ent.Comp.SupportedChannels.Contains(ent.Comp.CurrentChannel.Value))

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -23,6 +23,7 @@ using Content.Shared.Interaction;
 using Content.Shared.PDA;
 using Content.Shared.Popups;
 using Content.Shared.Power;
+using Content.Shared.Silicons.StationAi; // Ganimed-Edit: AI synthetic bypass (issue #208)
 using Content.Shared.Stacks;
 using Content.Shared.Tag;
 using Content.Shared.Throwing;
@@ -86,6 +87,12 @@ namespace Content.Server.VendingMachines
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineWithdrawMessage>(OnWithdrawMessage);
             //ADT-Economy-End
 
+            // Ganimed-Edit: AI synthetic bypass (issue #208)
+            Subs.BuiEvents<VendingMachineComponent>(VendingMachineUiKey.Key, subs =>
+            {
+                subs.Event<VendingMachineSyntheticBypassMessage>(OnSyntheticBypass);
+            });
+
             SubscribeLocalEvent<VendingMachineRestockComponent, PriceCalculationEvent>(OnPriceCalculation);
         }
 
@@ -126,9 +133,35 @@ namespace Content.Server.VendingMachines
         private void UpdateVendingMachineInterfaceState(EntityUid uid, VendingMachineComponent component)
         {
             var state = new VendingMachineInterfaceState(GetAllInventory(uid, component), component.PriceMultiplier,
-                component.Credits); //ADT-Economy
+                component.Credits,
+                // Ganimed-Edit: AI synthetic bypass (issue #208)
+                component.SyntheticBypassArmed,
+                (int) Math.Max(0, Math.Ceiling((component.NextSyntheticBypassTime - _timing.CurTime).TotalSeconds))); //ADT-Economy
 
             _userInterfaceSystem.SetUiState(uid, VendingMachineUiKey.Key, state);
+        }
+
+        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        private void OnSyntheticBypass(EntityUid uid, VendingMachineComponent component, VendingMachineSyntheticBypassMessage args)
+        {
+            if (!this.IsPowered(uid, EntityManager))
+                return;
+
+            if (!HasComp<StationAiHeldComponent>(args.Actor))
+                return;
+
+            if (_timing.CurTime < component.NextSyntheticBypassTime)
+            {
+                var remaining = (int)Math.Ceiling((component.NextSyntheticBypassTime - _timing.CurTime).TotalSeconds);
+                Popup.PopupEntity(Loc.GetString("vending-machine-synthetic-bypass-cooldown-popup", ("time", remaining)), uid, args.Actor);
+                return;
+            }
+
+            component.SyntheticBypassArmed = true;
+            component.NextSyntheticBypassTime = _timing.CurTime + TimeSpan.FromSeconds(VendingMachineComponent.SyntheticBypassCooldown);
+            UpdateVendingMachineInterfaceState(uid, component);
+            Audio.PlayPvs(component.SoundInsertCurrency, uid);
+            Popup.PopupEntity(Loc.GetString("vending-machine-synthetic-bypass-armed-popup"), uid, args.Actor);
         }
 
         private void OnInventoryEjectMessage(EntityUid uid, VendingMachineComponent component, VendingMachineEjectMessage args)
@@ -362,8 +395,11 @@ namespace Content.Server.VendingMachines
                 return;
 
             //ADT-Economy-Start
+            // Ganimed-Edit: AI synthetic bypass (issue #208)
+            var syntheticBypass = vendComponent.SyntheticBypassArmed && sender.HasValue && HasComp<StationAiHeldComponent>(sender.Value);
+
             var price = GetPrice(entry, vendComponent, count);
-            if (price > 0 && !vendComponent.AllForFree && sender.HasValue && !_tag.HasTag(sender.Value, "IgnoreBalanceChecks"))
+            if (price > 0 && !vendComponent.AllForFree && sender.HasValue && !_tag.HasTag(sender.Value, "IgnoreBalanceChecks") && !syntheticBypass)
             {
                 var success = false;
                 if (vendComponent.Credits >= price)
@@ -398,6 +434,14 @@ namespace Content.Server.VendingMachines
                     return;
                 }
             }
+
+            // Ganimed-Edit: AI synthetic bypass (issue #208)
+            if (syntheticBypass)
+            {
+                vendComponent.SyntheticBypassArmed = false;
+                UpdateVendingMachineInterfaceState(uid, vendComponent);
+            }
+
             vendComponent.NextItemCount = count;
             //ADT-Economy-End
 
@@ -596,6 +640,15 @@ namespace Content.Server.VendingMachines
                         comp.DispenseOnHitAccumulator = 0f;
                         comp.DispenseOnHitCoolingDown = false;
                     }
+                }
+
+                // Ganimed-Edit: tick the synthetic bypass cooldown down in the UI (issue #208)
+                if (comp.NextSyntheticBypassUiRefresh < _timing.CurTime &&
+                    TryComp<UserInterfaceComponent>(uid, out var ui) &&
+                    _userInterfaceSystem.IsUiOpen((uid, ui), VendingMachineUiKey.Key))
+                {
+                    comp.NextSyntheticBypassUiRefresh = _timing.CurTime + TimeSpan.FromSeconds(1);
+                    UpdateVendingMachineInterfaceState(uid, comp);
                 }
             }
             var disabled = EntityQueryEnumerator<EmpDisabledComponent, VendingMachineComponent>();

--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -142,6 +142,8 @@ namespace Content.Server.VendingMachines
         }
 
         // Ganimed-Edit: AI synthetic bypass (issue #208)
+        // The 120s cooldown (NextSyntheticBypassTime) gates the ARMING button itself, not the vend:
+        // once armed, the very next purchase by the AI is free (SyntheticBypassArmed is reset after it).
         private void OnSyntheticBypass(EntityUid uid, VendingMachineComponent component, VendingMachineSyntheticBypassMessage args)
         {
             if (!this.IsPowered(uid, EntityManager))

--- a/Content.Server/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
+++ b/Content.Server/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+using Content.Shared._Ganimed.Silicons.StationAi.Systems;
+using Content.Shared.Access.Systems;
+
+namespace Content.Server._Ganimed.Silicons.StationAi;
+
+/// <summary>
+/// Radial menu action for APCs controlled by the station AI.
+/// </summary>
+public sealed partial class StationAiApcRadialSystem : EntitySystem
+{
+    [Dependency] private readonly ApcSystem _apc = default!;
+    [Dependency] private readonly AccessReaderSystem _access = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ApcComponent, StationAiApcToggleBreakerEvent>(OnToggleBreaker);
+    }
+
+    private void OnToggleBreaker(EntityUid uid, ApcComponent component, StationAiApcToggleBreakerEvent args)
+    {
+        var attemptEv = new ApcToggleMainBreakerAttemptEvent();
+        RaiseLocalEvent(uid, ref attemptEv);
+        if (attemptEv.Cancelled)
+            return;
+
+        if (!_access.IsAllowed(args.User, uid))
+            return;
+
+        _apc.ApcToggleBreaker(uid, component);
+    }
+}

--- a/Content.Server/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
+++ b/Content.Server/_Ganimed/Silicons/StationAi/StationAiApcRadialSystem.cs
@@ -10,7 +10,11 @@ using Content.Shared.Access.Systems;
 namespace Content.Server._Ganimed.Silicons.StationAi;
 
 /// <summary>
-/// Radial menu action for APCs controlled by the station AI.
+/// Handles the AI radial menu action on APCs (main breaker toggle).
+/// A dedicated server system is needed because the breaker logic lives in the server-side
+/// <see cref="ApcSystem"/> (ApcComponent is server-only), while the radial action itself is a
+/// shared <see cref="StationAiApcToggleBreakerEvent"/> raised on the APC. The system runs the
+/// standard breaker attempt event plus an access check before toggling.
 /// </summary>
 public sealed partial class StationAiApcRadialSystem : EntitySystem
 {

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -217,7 +217,7 @@ namespace Content.Shared.VendingMachines
         [DataField, AutoNetworkedField]
         public Color UiButtonDisabledColor = Color.FromHex("#3f3f3fff");
 
-        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        // Ganimed-Add-Start: AI synthetic bypass (issue #208)
         /// <summary>
         /// The next AI vend is free of charge while this is true.
         /// </summary>
@@ -237,6 +237,7 @@ namespace Content.Shared.VendingMachines
         /// Cooldown of the synthetic bypass in seconds.
         /// </summary>
         public const float SyntheticBypassCooldown = 120f;
+        // Ganimed-Add-End: AI synthetic bypass
 
         //ADT-Economy-End
     }

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -217,6 +217,27 @@ namespace Content.Shared.VendingMachines
         [DataField, AutoNetworkedField]
         public Color UiButtonDisabledColor = Color.FromHex("#3f3f3fff");
 
+        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        /// <summary>
+        /// The next AI vend is free of charge while this is true.
+        /// </summary>
+        public bool SyntheticBypassArmed;
+
+        /// <summary>
+        /// When the AI is allowed to use the synthetic bypass again.
+        /// </summary>
+        public TimeSpan NextSyntheticBypassTime = TimeSpan.Zero;
+
+        /// <summary>
+        /// When the UI state should be refreshed to tick down the bypass cooldown.
+        /// </summary>
+        public TimeSpan NextSyntheticBypassUiRefresh = TimeSpan.Zero;
+
+        /// <summary>
+        /// Cooldown of the synthetic bypass in seconds.
+        /// </summary>
+        public const float SyntheticBypassCooldown = 120f;
+
         //ADT-Economy-End
     }
 

--- a/Content.Shared/VendingMachines/VendingMachineInterfaceState.cs
+++ b/Content.Shared/VendingMachines/VendingMachineInterfaceState.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.VendingMachines
         public double PriceMultiplier;
         public int Credits;
         //ADT-Economy-End
-        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        // Ganimed-Add-Start: AI synthetic bypass (issue #208)
         public bool SyntheticBypassArmed;
         public int SyntheticBypassCooldownRemaining;
         public VendingMachineInterfaceState(List<VendingMachineInventoryEntry> inventory, double priceMultiplier, int credits, bool syntheticBypassArmed = false, int syntheticBypassCooldownRemaining = 0) //ADT-Economy
@@ -23,6 +23,7 @@ namespace Content.Shared.VendingMachines
             SyntheticBypassArmed = syntheticBypassArmed;
             SyntheticBypassCooldownRemaining = syntheticBypassCooldownRemaining;
         }
+        // Ganimed-Add-End: AI synthetic bypass
     }
     //ADT-Economy-Start
     [Serializable, NetSerializable]
@@ -30,11 +31,12 @@ namespace Content.Shared.VendingMachines
     {
     }
 
-    // Ganimed-Edit: AI synthetic bypass (issue #208)
+    // Ganimed-Add-Start: AI synthetic bypass (issue #208)
     [Serializable, NetSerializable]
     public sealed class VendingMachineSyntheticBypassMessage : BoundUserInterfaceMessage
     {
     }
+    // Ganimed-Add-End: AI synthetic bypass
 
     [Serializable, NetSerializable]
     public sealed class VendingMachineEjectCountMessage : BoundUserInterfaceMessage

--- a/Content.Shared/VendingMachines/VendingMachineInterfaceState.cs
+++ b/Content.Shared/VendingMachines/VendingMachineInterfaceState.cs
@@ -10,18 +10,29 @@ namespace Content.Shared.VendingMachines
         public double PriceMultiplier;
         public int Credits;
         //ADT-Economy-End
-        public VendingMachineInterfaceState(List<VendingMachineInventoryEntry> inventory, double priceMultiplier, int credits) //ADT-Economy
+        // Ganimed-Edit: AI synthetic bypass (issue #208)
+        public bool SyntheticBypassArmed;
+        public int SyntheticBypassCooldownRemaining;
+        public VendingMachineInterfaceState(List<VendingMachineInventoryEntry> inventory, double priceMultiplier, int credits, bool syntheticBypassArmed = false, int syntheticBypassCooldownRemaining = 0) //ADT-Economy
         {
             Inventory = inventory;
             //ADT-Economy-Start
             PriceMultiplier = priceMultiplier;
             Credits = credits;
             //ADT-Economy-End
+            SyntheticBypassArmed = syntheticBypassArmed;
+            SyntheticBypassCooldownRemaining = syntheticBypassCooldownRemaining;
         }
     }
     //ADT-Economy-Start
     [Serializable, NetSerializable]
     public sealed class VendingMachineWithdrawMessage : BoundUserInterfaceMessage
+    {
+    }
+
+    // Ganimed-Edit: AI synthetic bypass (issue #208)
+    [Serializable, NetSerializable]
+    public sealed class VendingMachineSyntheticBypassMessage : BoundUserInterfaceMessage
     {
     }
 

--- a/Content.Shared/_Ganimed/Silicons/StationAi/Systems/StationAiApcEvents.cs
+++ b/Content.Shared/_Ganimed/Silicons/StationAi/Systems/StationAiApcEvents.cs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Silicons.StationAi;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Ganimed.Silicons.StationAi.Systems;
+
+/// <summary> Event for StationAI attempt at toggling an APC's main breaker. </summary>
+[Serializable, NetSerializable]
+public sealed class StationAiApcToggleBreakerEvent : BaseStationAiAction
+{
+}

--- a/Content.Shared/_Ganimed/Silicons/StationAi/Systems/StationAiRadialTurretSystem.cs
+++ b/Content.Shared/_Ganimed/Silicons/StationAi/Systems/StationAiRadialTurretSystem.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared.Access.Systems;
+using Content.Shared.Power.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.Silicons.StationAi;
+using Content.Shared.Turrets;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Ganimed.Silicons.StationAi.Systems;
+
+/// <summary>
+/// Radial menu actions for AI-controlled turrets.
+/// </summary>
+public sealed partial class StationAiRadialTurretSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPowerReceiverSystem _powerReceiver = default!;
+    [Dependency] private readonly AccessReaderSystem _access = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedDeployableTurretSystem _turrets = default!;
+    [Dependency] private readonly BatteryWeaponFireModesSystem _fireModes = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<StationAiTurretComponent, StationAiTurretToggleEvent>(OnTurretToggle);
+        SubscribeLocalEvent<StationAiTurretComponent, StationAiTurretCycleFireModeEvent>(OnTurretCycleFireMode);
+    }
+
+    private void OnTurretToggle(Entity<StationAiTurretComponent> ent, ref StationAiTurretToggleEvent args)
+    {
+        if (!_powerReceiver.IsPowered(ent.Owner) || !_access.IsAllowed(args.User, ent.Owner))
+            return;
+
+        if (!TryComp(ent.Owner, out DeployableTurretComponent? deployable))
+            return;
+
+        _turrets.TrySetState((ent.Owner, deployable), args.Enabled, args.User);
+    }
+
+    private void OnTurretCycleFireMode(Entity<StationAiTurretComponent> ent, ref StationAiTurretCycleFireModeEvent args)
+    {
+        if (!_powerReceiver.IsPowered(ent.Owner))
+            return;
+
+        if (!TryComp(ent.Owner, out BatteryWeaponFireModesComponent? fireModes))
+            return;
+
+        _fireModes.TryCycleFireMode(ent.Owner, fireModes, args.User);
+    }
+}
+
+/// <summary> Event for StationAI attempt at toggling a turret on/off. </summary>
+[Serializable, NetSerializable]
+public sealed class StationAiTurretToggleEvent : BaseStationAiAction
+{
+    public bool Enabled;
+}
+
+/// <summary> Event for StationAI attempt at cycling the turret's fire mode. </summary>
+[Serializable, NetSerializable]
+public sealed class StationAiTurretCycleFireModeEvent : BaseStationAiAction
+{
+}

--- a/Resources/Locale/en-US/_Ganimed/headset/headset-component.ftl
+++ b/Resources/Locale/en-US/_Ganimed/headset/headset-component.ftl
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+chat-radio-ai-private = AI Private

--- a/Resources/Locale/en-US/_Ganimed/silicons/station-ai-radial.ftl
+++ b/Resources/Locale/en-US/_Ganimed/silicons/station-ai-radial.ftl
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+ai-turret-enable = Enable turret
+ai-turret-disable = Disable turret
+ai-apc-toggle-breaker = Toggle main breaker

--- a/Resources/Locale/en-US/_Ganimed/vending/vending-machine.ftl
+++ b/Resources/Locale/en-US/_Ganimed/vending/vending-machine.ftl
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+vending-machine-synthetic-bypass = Synthetic bypass
+vending-machine-synthetic-bypass-armed = Bypass active
+vending-machine-synthetic-bypass-cooldown = Cooldown: { $time }s
+vending-machine-synthetic-bypass-armed-popup = Synthetic bypass activated. The next dispense is free.
+vending-machine-synthetic-bypass-cooldown-popup = Synthetic bypass is recharging: { $time }s.

--- a/Resources/Locale/ru-RU/_Ganimed/headset/headset-component.ftl
+++ b/Resources/Locale/ru-RU/_Ganimed/headset/headset-component.ftl
@@ -4,3 +4,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 chat-radio-conspiracy = Заговор
+
+chat-radio-ai-private = ИИ приватный

--- a/Resources/Locale/ru-RU/_Ganimed/silicons/station-ai-radial.ftl
+++ b/Resources/Locale/ru-RU/_Ganimed/silicons/station-ai-radial.ftl
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+ai-turret-enable = Включить турель
+ai-turret-disable = Выключить турель
+ai-apc-toggle-breaker = Переключить рубильник

--- a/Resources/Locale/ru-RU/_Ganimed/vending/vending-machine.ftl
+++ b/Resources/Locale/ru-RU/_Ganimed/vending/vending-machine.ftl
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+vending-machine-synthetic-bypass = Синтетический обход
+vending-machine-synthetic-bypass-armed = Обход активен
+vending-machine-synthetic-bypass-cooldown = Перезарядка: { $time } с
+vending-machine-synthetic-bypass-armed-popup = Синтетический обход активирован. Следующая выдача бесплатна.
+vending-machine-synthetic-bypass-cooldown-popup = Синтетический обход перезаряжается: { $time } с.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,6 +16,7 @@
     - Security
     - Service
     - Supply
+    - AiPrivate # Ganimed-Edit: AI private channel (issue #208)
   - type: ActiveRadio
     channels:
     - Binary
@@ -27,6 +28,7 @@
     - Security
     - Service
     - Supply
+    - AiPrivate # Ganimed-Edit: AI private channel (issue #208)
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: RadioJobIconOverride # ADT-Tweak

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
@@ -129,6 +129,8 @@
     interfaces:
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
+      enum.AiUi.Key: # Ganimed-Edit: AI radial menu for turrets (issue #208)
+        type: StationAiBoundUserInterface
   - type: WiresPanel
   - type: WiresVisuals
   - type: Wires

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -88,6 +88,8 @@
         type: ApcBoundUserInterface
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
+      enum.AiUi.Key: # Ganimed-Edit: AI radial menu for APCs (issue #208)
+        type: StationAiBoundUserInterface
   - type: ActivatableUI
     inHandsOnly: false
     key: enum.ApcUiKey.Key

--- a/Resources/Prototypes/_Ganimed/radio_channels.yml
+++ b/Resources/Prototypes/_Ganimed/radio_channels.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 ultradyper <ultradyper@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: radioChannel
+  id: AiPrivate
+  name: chat-radio-ai-private
+  keycode: 'л'
+  frequency: 1499
+  color: "#66ccff"


### PR DESCRIPTION
## Описание PR

Три механики ИИ станции из задачи #208:

- **AI Private канал**: приватный радиоканал для ИИ (`AiPrivate`, keycode «л», частота 1499). Интеркомы всегда поддерживают его (даже без ключей шифрования), добавлен в радио ИИ.
- **Синтетический обход вендоматов**: кнопка в меню вендомата, видимая только ИИ. Активация делает следующую покупку ИИ бесплатной. Кд 120 секунд на сам вендомат, отсчёт тикает в UI. Вопросы баланса (нужность частного канала и байпаса) - к #208, оценка от @Imperator-Shlepa и @ThundraBoomerov.
- **Радиал турелей и ЛКП**: ИИ может через глагол «Открыть действия» управлять турелями (вкл/выкл, смена режима огня) и ЛКП (переключение рубильника), если у него есть доступ к устройству.

## Технические детали

- `Resources/Prototypes/_Ganimed/radio_channels.yml` - новый канал `AiPrivate`.
- `Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs` - интеркомы получают канал при ComponentInit (правка помечена `// Ganimed-Edit`).
- `Content.Shared/VendingMachines/VendingMachineComponent.cs` + `VendingMachineInterfaceState.cs` - поля байпаса и сообщение, блоки помечены `// Ganimed-Add-Start/End`.
- `Content.Server/VendingMachines/VendingMachineSystem.cs` - серверная логика байпаса: проверка, что покупатель ИИ (`StationAiHeldComponent`), кд, сброс арма после первой покупки, рефреш UI раз в секунду пока открыт.
- `Content.Client/ADT/VendingMachines/UI/FancyVendingMachineMenu.xaml(.cs)` + `VendingMachineBoundUserInterface.cs` - кнопка, видимая только для ИИ.
- `Content.Shared/_Ganimed/Silicons/StationAi/Systems/StationAiRadialTurretSystem.cs` + `StationAiApcEvents.cs`, `Content.Server/_Ganimed/.../StationAiApcRadialSystem.cs`, клиентские системы радиала - обработка радиальных действий ИИ с проверкой доступа и питания.
- YAML: `UserInterface` с `AiUi.Key` у турелей (`turrets_energy.yml`) и ЛКП (`apc.yml`).

## Медиа

Скриншоты добавлю отдельным коммитом.

## Чек-лист

- [ ] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [ ] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений

:cl:
- add: Добавлен приватный радиоканал ИИ станции.
- add: ИИ станции может активировать синтетический обход вендоматов (бесплатная покупка, кд 120с).
- add: ИИ станции может управлять турелями и ЛКП через радиальное меню действий.
