### PR TITLE
Тритий в вейпах: радиация теперь в моде

### DIFF
--- a/Content.Server/Nutrition/Components/VapeComponent.cs
+++ b/Content.Server/Nutrition/Components/VapeComponent.cs
@@ -39,6 +39,22 @@ namespace Content.Server.Nutrition.Components // Vapes are very nutritious.
         [ViewVariables(VVAccess.ReadWrite)]
         public float ReductionFactor { get; set; } = 300f;
 
+        // Ganimed-Add-Start (vape tritium)
+        /// <summary>
+        /// Amount of tritium released into the atmosphere with each use.
+        /// </summary>
+        [DataField("tritiumPerUse")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float TritiumPerUse { get; set; } = 0.05f;
+
+        /// <summary>
+        /// How much of the solution is consumed with each use.
+        /// </summary>
+        [DataField("volumePerUse")]
+        [ViewVariables(VVAccess.ReadWrite)]
+        public float VolumePerUse { get; set; } = 2f;
+        // Ganimed-Add-End (vape tritium)
+
         // TODO when this gets fixed, use prototype serializers
         [DataField("solutionNeeded")]
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
+++ b/Content.Server/Nutrition/EntitySystems/SmokingSystem.Vape.cs
@@ -7,6 +7,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Emag.Systems;
+using Content.Shared.FixedPoint;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Nutrition;
@@ -133,12 +134,20 @@ namespace Content.Server.Nutrition.EntitySystems
             //Smoking kills(your lungs, but there is no organ damage yet)
             _damageableSystem.TryChangeDamage(args.Args.Target.Value, entity.Comp.Damage, true);
 
+            // Ganimed-Edit-Start (vape tritium): vapes release a fixed portion of their
+            // solution per use instead of the whole tank, plus a bit of tritium.
+            var volumeUsed = FixedPoint2.Min(FixedPoint2.New(entity.Comp.VolumePerUse), args.Solution.Volume);
+
             var merger = new GasMixture(1) { Temperature = args.Solution.Temperature };
-            merger.SetMoles(entity.Comp.GasType, args.Solution.Volume.Value / entity.Comp.ReductionFactor);
+            merger.SetMoles(entity.Comp.GasType, volumeUsed.Value / entity.Comp.ReductionFactor);
+
+            if (entity.Comp.TritiumPerUse > 0)
+                merger.AdjustMoles(Gas.Tritium, entity.Comp.TritiumPerUse);
 
             _atmos.Merge(environment, merger);
 
-            args.Solution.RemoveAllSolution();
+            args.Solution.RemoveSolution(volumeUsed);
+            // Ganimed-Edit-End (vape tritium)
 
             if (args.Forced)
             {

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
@@ -7,6 +7,12 @@
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Vapes/vape-standard.rsi
     state: icon
+  # Ganimed-Add-Start (vape tritium): way more vapor, big tank, fixed portion per use and a bit of tritium.
+  - type: Vape
+    reductionFactor: 4
+    volumePerUse: 2
+    tritiumPerUse: 0.05
+  # Ganimed-Add-End (vape tritium)
   # ADT Tweak Start
   - type: StaticPrice
     price: 100

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/base_smokeables.yml
@@ -79,7 +79,8 @@
   - type: SolutionContainerManager
     solutions:
       smokable:
-        maxVol: 10
+        # Ganimed-Edit: tank increased from 10 to 200u so the vape lasts 100 puffs.
+        maxVol: 200
   - type: RefillableSolution
     solution: smokable
   - type: ExaminableSolution


### PR DESCRIPTION
## Описание PR

Рофл-PR, не серьёзный. Теперь каждый вейпер потихоньку травит станцию тритием. Дым из вейпа не просто пар, а радиоактивный газ. Медики будут любить курильщиков ещё больше.

## Технические детали

- `VapeComponent` - новые поля `TritiumPerUse` (0.05u трития за затяжку) и `VolumePerUse` (2u раствора за затяжку вместо всего бака).
- `SmokingSystem.Vape` - затяжка забирает фиксированную порцию раствора, а в атмосферу уходит тритий.
- `vape.yml` - вейп с этими настройками.
- `base_smokeables.yml` - бак увеличен с 10u до 200u, чтобы вейпа хватило на 100 затяжек (иначе он кончался бы за 5).

## Медиа

Скриншотов нет, рофл-PR.

## Чек-лист

- [X] PR полностью завершён и мне не нужна помощь, чтобы его закончить.
- [X] Я запускал локальный сервер со своими изменениями, всё протестировал, и всё работает как должно.

## Список изменений

:cl:
- tweak: Вейпы теперь выделяют тритий при курении.