### PR TITLE
add: Докрутка рыбалки: счётчик улова и golden rod, лут в лаве и плазме

### DIFF
--- a/Content.Server/ADT/Fishing/FishingSystem.cs
+++ b/Content.Server/ADT/Fishing/FishingSystem.cs
@@ -22,6 +22,7 @@ public sealed class FishingSystem : SharedFishingSystem
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly PhysicsSystem _physics = default!;
+    [Dependency] private readonly FishingStatsSystem _fishingStats = default!;
 
     public override void Initialize()
     {
@@ -134,6 +135,10 @@ public sealed class FishingSystem : SharedFishingSystem
         direction *= distance / length;
 
         Throwing.TryThrow(fish, direction, 7f);
+
+        // ADT-Fishing-Stats: считаем только рыбу, мусор и хлам не в счёт
+        if (_proto.Index(fishId).TryGetComponent(out FishComponent? _, _compFactory))
+            _fishingStats.AddCaughtFish(target);
     }
 
     protected override void CalculateFightingTimings(Entity<ActiveFisherComponent> fisher, ActiveFishingSpotComponent activeSpotComp)

--- a/Content.Shared/ADT/Fishing/Components/FishingStatsComponent.cs
+++ b/Content.Shared/ADT/Fishing/Components/FishingStatsComponent.cs
@@ -1,0 +1,42 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.ADT.Fishing.Components;
+
+/// <summary>
+/// Stores fishing statistics for a holder, such as an ID card.
+/// Used to track caught fish and grant the golden fishing rod trophy.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FishingStatsComponent : Component
+{
+    /// <summary>
+    /// Total amount of fish caught (junk and treasure do not count).
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public uint FishCaught;
+
+    /// <summary>
+    /// Whether the golden rod trophy has already been granted.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool GoldenRodGranted;
+
+    /// <summary>
+    /// Amount of fish required to receive the golden rod trophy.
+    /// </summary>
+    [DataField]
+    public uint GoldenRodThreshold = 250;
+
+    /// <summary>
+    /// How often to show a progress popup (every N fish).
+    /// </summary>
+    [DataField]
+    public uint PopupInterval = 50;
+
+    /// <summary>
+    /// Prototype of the trophy granted at the threshold.
+    /// </summary>
+    [DataField]
+    public EntProtoId GoldenRodPrototype = "ADTFishingRodGolden";
+}

--- a/Content.Shared/ADT/Fishing/Systems/FishingStatsSystem.cs
+++ b/Content.Shared/ADT/Fishing/Systems/FishingStatsSystem.cs
@@ -1,0 +1,66 @@
+using Content.Shared.Access.Systems;
+using Content.Shared.ADT.Fishing.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Popups;
+
+namespace Content.Shared.ADT.Fishing.Systems;
+
+/// <summary>
+/// Tracks fishing statistics stored on the fisher's ID card.
+/// </summary>
+public sealed class FishingStatsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedIdCardSystem _idCard = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    /// <summary>
+    /// Finds the user's ID card and ensures a <see cref="FishingStatsComponent"/> on it.
+    /// </summary>
+    public bool TryGetStats(EntityUid user, out EntityUid idCard, out FishingStatsComponent comp)
+    {
+        if (_idCard.TryFindIdCard(user, out var card))
+        {
+            idCard = card;
+            comp = EnsureComp<FishingStatsComponent>(idCard);
+            return true;
+        }
+
+        idCard = EntityUid.Invalid;
+        comp = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Registers one caught fish on the user's ID card.
+    /// Shows progress popups every <see cref="FishingStatsComponent.PopupInterval"/> fish
+    /// and grants the golden rod trophy at <see cref="FishingStatsComponent.GoldenRodThreshold"/>.
+    /// </summary>
+    public void AddCaughtFish(EntityUid user)
+    {
+        if (!TryGetStats(user, out var idCard, out var comp))
+            return;
+
+        comp.FishCaught++;
+        Dirty(idCard, comp);
+
+        if (comp.FishCaught >= comp.GoldenRodThreshold && !comp.GoldenRodGranted)
+        {
+            comp.GoldenRodGranted = true;
+            Dirty(idCard, comp);
+
+            var rod = Spawn(comp.GoldenRodPrototype, Transform(user).Coordinates);
+            _hands.TryPickupAnyHand(user, rod);
+
+            _popup.PopupEntity(
+                Loc.GetString("fishing-golden-rod-granted", ("count", comp.FishCaught)),
+                user, user, PopupType.Medium);
+        }
+        else if (comp.FishCaught % comp.PopupInterval == 0)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("fishing-caught-progress", ("count", comp.FishCaught)),
+                user, user);
+        }
+    }
+}

--- a/Resources/Locale/ru-RU/ADT/fishing/fishing.ftl
+++ b/Resources/Locale/ru-RU/ADT/fishing/fishing.ftl
@@ -9,3 +9,5 @@ ent-ActionStartFishing = Закинуть крючок
 
 ent-ActionStopFishing = Потянуть за удочку
     .desc = Потяните за удочку, чтобы прекратить рыбалку.
+fishing-caught-progress = Вы поймали { $count } рыб!
+fishing-golden-rod-granted = Наконец-то, { $count } рыб! Вот ваш трофей.

--- a/Resources/Prototypes/ADT/Entities/Objects/Specific/Fishing/loot_tables.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Specific/Fishing/loot_tables.yml
@@ -67,11 +67,56 @@
         weight: 10
 
 - type: entityTable
+  id: LavaLootTable
+  table: !type:GroupSelector
+    children:
+    - id: GoldOre1
+      amount: !type:RangeNumberSelector
+        range: 1, 2
+    - id: SilverOre1
+      amount: !type:RangeNumberSelector
+        range: 1, 3
+    - id: PlasmaOre1
+      amount: !type:RangeNumberSelector
+        range: 2, 4
+    - id: Igniter
+    - id: ClothingHeadHelmetFire
+    - id: WeldingFuelTank
+
+- type: entityTable
   id: LavaFishingLootTable
   table: !type:GroupSelector
     children:
       - !type:NestedSelector
         tableId: BasicFishingLootTable
+        weight: 55
+      - !type:NestedSelector
+        tableId: LavaLootTable
+        weight: 25
+      - !type:NestedSelector
+        tableId: SalvageTreasureCommon
+        weight: 15
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 5
+
+- type: entityTable
+  id: PlasmaLootTable
+  table: !type:GroupSelector
+    children:
+    - id: PlasmaOre1
+      amount: !type:RangeNumberSelector
+        range: 3, 5
+    - id: SheetPlasma1
+      amount: !type:RangeNumberSelector
+        range: 2, 4
+    - id: UraniumOre1
+      amount: !type:RangeNumberSelector
+        range: 1, 2
+    - id: PowerCellSmall
+      amount: !type:RangeNumberSelector
+        range: 1, 2
+    - id: GoldOre1
 
 - type: entityTable
   id: PlasmaFishingLootTable
@@ -79,3 +124,13 @@
     children:
       - !type:NestedSelector
         tableId: BasicFishingLootTable
+        weight: 55
+      - !type:NestedSelector
+        tableId: PlasmaLootTable
+        weight: 25
+      - !type:NestedSelector
+        tableId: SalvageTreasureCommon
+        weight: 15
+      - !type:NestedSelector
+        tableId: SalvageTreasureUncommon
+        weight: 5


### PR DESCRIPTION
Докрутка рыбалки:

1. Счётчик улова на ID-карте (FishingStatsComponent + FishingStatsSystem):
   - Каждая пойманная рыба (мусор и хлам не считаются) добавляет +1 к счётчику на ID-карте рыбака.
   - Поп-ап прогресса каждые 50 рыб.
   - На 250 пойманных рыб выдаётся трофейная golden rod (автовыдача в руки, иначе на пол), повторно не выдаётся.

2. Лут в лаве и жидкой плазме:
   - Лава: 55% мусор + 25% лавовый лут (золотая/серебряная руда, плазменная руда, Igniter, пожарный шлем, топливная бочка) + 15% SalvageTreasureCommon + 5% Uncommon.
   - Плазма: 55% мусор + 25% плазменный лут (плазменная руда, листы плазмы, уран, батарейки) + 15% Common + 5% Uncommon.

Проверки: dotnet build --configuration DebugOpt 0 ошибок, YAML Linter чистый.
